### PR TITLE
[FIX] Bug onde o campo internal_number (Numero da fatura) não exibe nenhum valor

### DIFF
--- a/l10n_br_account/account_invoice_view.xml
+++ b/l10n_br_account/account_invoice_view.xml
@@ -44,6 +44,8 @@
 				<field position="attributes" name="company_id">
 					<attribute name="on_changes">onchange_company_id(company_id, partner_id, type, invoice_line, currency_id, fiscal_category_id)</attribute>
 				</field>
+                <field position="replace" name="internal_number"/>
+                
 				<field name="date_invoice" position="before">
 					<field name="internal_number" attrs="{'readonly': [('issuer', '=', '0')], 'required': [('issuer', '=', '1')]}" />
 					<field name="vendor_serie" attrs="{'invisible': [('issuer', '=', '0')], 'required': [('issuer', '=', '1')]}" />


### PR DESCRIPTION
Correção do bug onde o campo "Numero da fatura" da fatura não exibe nenhum valor (apesar de estar presente no banco)
