### PR TITLE
[FIX] Erro ao selecionar endereço de entrega na view de fatura provisoria.

### DIFF
--- a/l10n_br_account_product/account_invoice_view.xml
+++ b/l10n_br_account_product/account_invoice_view.xml
@@ -243,7 +243,7 @@
 					</page>
 				</notebook>
 				<field position="after" name="partner_id">
-					<field domain="[('partner_id', '=', partner_id)]" name="partner_shipping_id" />
+					<field domain="[('parent_id', '=', partner_id)]" name="partner_shipping_id" />
 				</field>
 				<button name="invoice_open" position="replace">
 					<button name="invoice_validate" states="draft" string="Confirmar" class="oe_highlight" />


### PR DESCRIPTION
Erro apresentado quando selecionamos o endereço de entrega na view de faturas provisorias.

Incidente id=95
