### PR TITLE
[FIX] Correção do bug de Impostos globais ao confirmar fatura.

### DIFF
--- a/l10n_br_account_product/account_invoice.py
+++ b/l10n_br_account_product/account_invoice.py
@@ -1114,7 +1114,7 @@ class AccountInvoiceTax(orm.Model):
                     val['account_id'] = tax['account_paid_id'] or line.account_id.id
                     val['account_analytic_id'] = tax['account_analytic_paid_id']
 
-                key = (val['tax_code_id'], val['base_code_id'], val['account_id'], val['account_analytic_id'])
+                key = (val['tax_code_id'], val['base_code_id'], val['account_id'])
                 if not key in tax_grouped:
                     tax_grouped[key] = val
                 else:


### PR DESCRIPTION
Erro "Impostos globais definido, mas não se encontram em linhas de fatura!" que ocorre ao tentarmos confirmar uma fatura. Mesmo com tudo configurado o erro ainda é apresentado.
