### PR TITLE
Sale product valor bruto subtotal

### DIFF
--- a/l10n_br_sale_product/sale.py
+++ b/l10n_br_sale_product/sale.py
@@ -337,7 +337,7 @@ class SaleOrderLine(orm.Model):
             # following line
             res[line.id]['discount_value'] = res[line.id]['price_gross']-\
                                              (price * qty)
-        a = 0
+
         return res
 
     _columns = {

--- a/l10n_br_sale_product/sale.py
+++ b/l10n_br_sale_product/sale.py
@@ -291,9 +291,6 @@ class SaleOrderLine(orm.Model):
     _inherit = 'sale.order.line'
 
     def _calc_line_base_price(self, cr, uid, line, context=None):
-        return line.price_unit
-
-    def _calc_line_base_price_discount(self, cr, uid, line, context=None):
         return line.price_unit * (1 - (line.discount or 0.0) / 100.0)
 
     def _calc_line_quantity(self, cr, uid, line, context=None):
@@ -313,14 +310,12 @@ class SaleOrderLine(orm.Model):
                 'discount_value': 0.0,
             }
             price = self._calc_line_base_price(cr, uid, line, context=context)
-            price_discount = self._calc_line_base_price_discount(
-                cr, uid, line, context=context)
             qty = self._calc_line_quantity(cr, uid, line, context=context)
             taxes = tax_obj.compute_all(
                 cr,
                 uid,
                 line.tax_id,
-                price_discount,
+                price,
                 qty,
                 line.order_id.partner_invoice_id.id,
                 line.product_id,
@@ -333,8 +328,7 @@ class SaleOrderLine(orm.Model):
             cur = line.order_id.pricelist_id.currency_id
             res[line.id]['price_subtotal'] = cur_obj.round(
                 cr, uid, cur, taxes['total'])
-            res[line.id]['price_gross'] = price * qty
-            # following line
+            res[line.id]['price_gross'] =  line.price_unit * qty
             res[line.id]['discount_value'] = res[line.id]['price_gross']-\
                                              (price * qty)
 


### PR DESCRIPTION
The price used on 'price_gross' was the one returned on _calc_line_base_price, which was wrong and made Price Gross appear the same as Price Subtotal.
Now price_gross is the price unit multiplied by quantity.
