### PR TITLE
[FIX] Tipo de frete não depende de existir uma transportadora

### DIFF
--- a/l10n_br_account_product/sped/nfe/document.py
+++ b/l10n_br_account_product/sped/nfe/document.py
@@ -412,9 +412,10 @@ class NFe200(FiscalDocument):
         #
         # Dados da Transportadora e veiculo
         #
-        if inv.carrier_id:
 
-            self.nfe.infNFe.transp.modFrete.valor = inv.incoterm and inv.incoterm.freight_responsibility or '9'
+        self.nfe.infNFe.transp.modFrete.valor = inv.incoterm and inv.incoterm.freight_responsibility or '9'
+
+        if inv.carrier_id:
 
             if inv.carrier_id.partner_id.is_company:
                 self.nfe.infNFe.transp.transporta.CNPJ.valor = \


### PR DESCRIPTION
O tipo de frete selecionado não estava sendo impresso no DANFE a menos que o campo "Transportadora" estivesse preenchido. A correção torna o tipo de frete independente de existir uma Transportadora selecionada na fatura.
