### PR TITLE
Revert "[FIX] onchange_partner_id in l10n_br_purchase"

### DIFF
--- a/l10n_br_purchase/purchase.py
+++ b/l10n_br_purchase/purchase.py
@@ -96,6 +96,9 @@ class PurchaseOrder(orm.Model):
         if not context:
             context = {}
 
+        res = super(PurchaseOrder, self).onchange_partner_id(
+            cr, uid, ids, partner_id)
+
         # TODO try to upstream web_context_tunnel in fiscal-rules
         # to avoid having to change this signature
         fiscal_category_id = context.get('fiscal_category_id')
@@ -103,9 +106,16 @@ class PurchaseOrder(orm.Model):
             company_id = self.pool['res.users'].browse(
                 cr, uid, uid, context).company_id.id
 
-        return super(PurchaseOrder, self).onchange_partner_id(
-            cr, uid, ids, partner_id, company_id, context,
-            fiscal_category_id=fiscal_category_id, **kwargs)
+        res['value'].update({
+            'fiscal_category_id': fiscal_category_id,
+            'company_id': company_id
+        })
+
+        return res
+
+        # return super(PurchaseOrder, self).onchange_partner_id(
+        #     cr, uid, ids, partner_id, company_id, context,
+        #     fiscal_category_id=fiscal_category_id, **kwargs)
 
     def onchange_dest_address_id(self, cr, uid, ids, partner_id,
                                  dest_address_id, company_id, context,


### PR DESCRIPTION
O merge [https://github.com/kmee/l10n-brazil/pull/40] a ser revertido estava causando o seguinte erro:

File "/opt/openerp/eurotel/v7/parts/l10n_br/l10n_br_core/l10n_br_purchase/purchase.py", line 108, in onchange_partner_id
    fiscal_category_id=fiscal_category_id, **kwargs)
TypeError: onchange_partner_id() takes exactly 5 arguments (8 given)

Em algumas bases especificas. Desfiz o merge para que o mesmo seja revisado novamente em diferentes bases de dados. 
