### PR TITLE
[FIX] Data da fatura não aparece na view em lista e numero fatura não visivel na view em formulário

### DIFF
--- a/l10n_br_account_product/account_invoice.py
+++ b/l10n_br_account_product/account_invoice.py
@@ -581,6 +581,22 @@ class AccountInvoice(orm.Model):
                 self.write(cr, uid, [inv.id], res['value'])
         return True
 
+    def create(self, cr, uid, vals, context=None):
+        if 'date_hour_invoice' in vals and vals['date_hour_invoice']:
+            aux = datetime.datetime.strptime(vals['date_hour_invoice'],
+                                             '%Y-%m-%d %H:%M:%S').date()
+            vals['date_invoice'] = str(aux)
+        return super(AccountInvoice, self).create(cr, uid, vals,
+                                                  context=context)
+
+    def write(self, cr, uid, ids, vals, context=None):
+        if 'date_hour_invoice' in vals and vals['date_hour_invoice']:
+            aux = datetime.datetime.strptime(vals['date_hour_invoice'],
+                                             '%Y-%m-%d %H:%M:%S').date()
+            vals['date_invoice'] = str(aux)
+        return super(AccountInvoice, self).write(cr, uid, ids, vals,
+                                                 context=context)
+
 
 class AccountInvoiceLine(orm.Model):
     _inherit = 'account.invoice.line'

--- a/l10n_br_account_product/account_invoice_view.xml
+++ b/l10n_br_account_product/account_invoice_view.xml
@@ -18,6 +18,7 @@
                 <field name="date_invoice" position="replace">
 					<field name="date_invoice" invisible="1"/>
 				</field>
+				<field name="internal_number" position="replace"/>
 				<notebook position="inside">
 					<page string="Documentos Relacionados">
 						<field colspan="4" nolabel="1" name="fiscal_document_related_ids">
@@ -161,6 +162,8 @@
                 <field name="date_invoice" position="replace">
 					<field name="date_invoice" invisible="1"/>
 				</field>
+                <field name="internal_number" position="replace"/>
+
 				<notebook>
 					<page string="Documentos Relacionados">
 						<field colspan="4" nolabel="1" name="fiscal_document_related_ids">


### PR DESCRIPTION
- [FIX] Na visão lista da fatura de fornecedor, o valor do campo Data da fatura (date_invoice) era sincronizado com o valor do campo **date_hour_invoice** apenas quando confirmávamos a fatura. Agora ele é sincronizado quando criamos/editamos a fatura. A visão de lista não mostrava a data da fatura mesmo quando esta já estava setada em **date_hour_invoice**
- [FIX] Campo número da fatura (**internal_number**) estava com seu conteúdo sendo ocultado por outro campo **internal_number**. O conteudo que era mostrado na visão lista não era o mesmo que era exibido na visão de formulário, por causa dos campos **internal_number** estarem duplicados na view formulario. Isso ocorre nas faturas de fornecedor e cliente.
