### PR TITLE
[FIX] passando objeto account.tax para o metodo map_tax

### DIFF
--- a/l10n_br_account_product/models/account_invoice.py
+++ b/l10n_br_account_product/models/account_invoice.py
@@ -977,7 +977,7 @@ class AccountInvoiceLine(models.Model):
                         account_id = kwargs['account_id']
                         taxes = account_obj.browse(account_id).tax_ids
                     else:
-                        taxes = [(6, 0, [])]
+                        taxes = self.env['account.tax'].browse([])
                 else:
                     ctx['type_tax_use'] = 'purchase'
                     if product.supplier_taxes_id:
@@ -986,7 +986,7 @@ class AccountInvoiceLine(models.Model):
                         account_id = kwargs['account_id']
                         taxes = account_obj.browse(account_id).tax_ids
                     else:
-                        taxes = [(6, 0, [])]
+                        taxes = self.env['account.tax'].browse([])
                 tax_ids = fp.with_context(ctx).map_tax(taxes)
                 result_rule['value']['invoice_line_tax_id'] = tax_ids.ids
                 result['value'].update(self._get_tax_codes(


### PR DESCRIPTION
Por causa do seguinte erro:

/l10n-brazil/l10n_br_account_product/models/res_partner.py", line 120, in _map_tax
    taxes |= tax_def.tax_id
TypeError: unsupported operand type(s) for |=: 'list' and 'account.tax'
