### PR TITLE
[FIX] ValueError: Wrong value for res.partner.partner_fiscal_type_id

### DIFF
--- a/l10n_br_account/models/res_partner.py
+++ b/l10n_br_account/models/res_partner.py
@@ -318,7 +318,8 @@ class ResPartner(models.Model):
         o tipo fiscal para não contribuinte já que quando é criado um novo
         parceiro o valor do campo is_company é false"""
         ft_ids = self.env['l10n_br_account.partner.fiscal.type'].search(
-            [('default', '=', 'True'), ('is_company', '=', is_company)])
+            [('default', '=', 'True'), ('is_company', '=', is_company)],
+            limit=1)
         return ft_ids
 
     partner_fiscal_type_id = fields.Many2one(


### PR DESCRIPTION
Vendas->Clientes e pressionar o botão "Criar".

Msg Erro: _ValueError: Wrong value for res.partner.partner_fiscal_type_id: l10n_br_account.partner.fiscal.type(4, 6)_
