### PR TITLE
Fix/calculo icms st base e ajustes

### DIFF
--- a/l10n_br_account_product/models/account.py
+++ b/l10n_br_account_product/models/account.py
@@ -339,7 +339,7 @@ class AccountTax(models.Model):
             result_icmsst['taxes'][0][
                 'icms_st_base_other'] = icms_st_base_other
 
-            if result_icmsst['taxes'][0]['percent'] and not \
+            if result_icmsst['taxes'][0]['percent'] and fiscal_position and not \
                     fiscal_position.icms_st_extract:
                 calculed_taxes += result_icmsst['taxes']
             elif result_icmsst['taxes'][0]['percent']:

--- a/l10n_br_account_product/models/account_invoice.py
+++ b/l10n_br_account_product/models/account_invoice.py
@@ -111,13 +111,9 @@ class AccountInvoice(models.Model):
                 self.icms_base += 0.00
                 self.icms_base_other += 0.00
                 self.icms_value += 0.00
-            if line.icms_cst_id.code in ('10', '30', '60', '90'):
-                self.icms_st_base += line.icms_st_base
-                self.icms_st_value += line.icms_st_value
-            else:
-                self.icms_st_base += 0.00
-                self.icms_st_value += 0.00
 
+            self.icms_st_base += line.icms_st_base
+            self.icms_st_value += line.icms_st_value
 
     @api.model
     @api.returns('l10n_br_account.fiscal_category')


### PR DESCRIPTION
Corrige o erro:
"Total da BC ICMS-ST difere do somatorio dos itens. (vBCST informado: 0.00, vBCST calculado: xxxx)"

O valor do ICMS ST base das linhas estavam divergindo do valor total.
