### PR TITLE
Devolucao fix

### DIFF
--- a/l10n_br_account_product/models/l10n_br_account.py
+++ b/l10n_br_account_product/models/l10n_br_account.py
@@ -12,12 +12,20 @@ from .l10n_br_account_product import (
 )
 
 
+FISCAL_CATEGORY_PURPOSE = [
+    ('1', 'Normal'),
+    ('2', 'Complementar'),
+    ('3', 'Ajuste'),
+    ('4', u'Devolução de Mercadoria')]
+
 class L10nBrAccountFiscalCategory(models.Model):
     _inherit = 'l10n_br_account.fiscal.category'
 
     fiscal_type = fields.Selection(
         PRODUCT_FISCAL_TYPE, 'Tipo Fiscal', required=True,
         default=PRODUCT_FISCAL_TYPE_DEFAULT)
+
+    purpose = fields.Selection(FISCAL_CATEGORY_PURPOSE, u'Finalidade')
 
 
 class L10nBrAccountDocumentSerie(models.Model):

--- a/l10n_br_account_product/views/l10n_br_account_view.xml
+++ b/l10n_br_account_product/views/l10n_br_account_view.xml
@@ -10,6 +10,9 @@
                 <field name="fiscal_type" position="attributes">
                     <attribute name="invisible">0</attribute>
                 </field>
+                <field name="fiscal_type" position="after">
+                    <field name="purpose" />
+                </field>
             </field>
         </record>
 
@@ -26,3 +29,4 @@
 
     </data>
 </openerp>
+

--- a/l10n_br_stock_account/__openerp__.py
+++ b/l10n_br_stock_account/__openerp__.py
@@ -14,6 +14,7 @@
         'l10n_br_stock',
         'account_fiscal_position_rule_stock',
         'stock_account',
+        'stock_picking_invoice_link'
     ],
     'data': [
         'data/l10n_br_stock_account_data.xml',

--- a/l10n_br_stock_account/models/stock_account.py
+++ b/l10n_br_stock_account/models/stock_account.py
@@ -16,8 +16,8 @@ class StockPicking(models.Model):
     @api.depends('invoice_id.nfe_access_key')
     def _get_fiscal_document_access_key(self):
         for picking in self:
-            picking.fiscal_document_access_key =\
-                picking.invoice_id and picking.invoice_id.nfe_access_key or ''
+            picking.fiscal_document_access_key = \
+                picking.invoice_id.nfe_access_key if picking.invoice_id else ''
 
     fiscal_category_id = fields.Many2one(
         'l10n_br_account.fiscal.category', 'Categoria Fiscal',

--- a/l10n_br_stock_account/models/stock_account.py
+++ b/l10n_br_stock_account/models/stock_account.py
@@ -12,6 +12,13 @@ class StockPicking(models.Model):
     def _default_fiscal_category(self):
         return self.env.user.company_id.stock_fiscal_category_id
 
+    @api.multi
+    @api.depends('invoice_id.nfe_access_key')
+    def _get_fiscal_document_access_key(self):
+        for picking in self:
+            picking.fiscal_document_access_key =\
+                picking.invoice_id and picking.invoice_id.nfe_access_key or ''
+
     fiscal_category_id = fields.Many2one(
         'l10n_br_account.fiscal.category', 'Categoria Fiscal',
         readonly=True, domain="[('state', '=', 'approved')]",
@@ -21,6 +28,9 @@ class StockPicking(models.Model):
         'account.fiscal.position', u'Posição Fiscal',
         domain="[('fiscal_category_id','=',fiscal_category_id)]",
         readonly=True, states={'draft': [('readonly', False)]})
+    fiscal_document_access_key = fields.Char(
+        u'Chave de acesso do Documento',
+        compute=_get_fiscal_document_access_key, store=True)
 
     def _fiscal_position_map(self, result, **kwargs):
         ctx = dict(self.env.context)
@@ -56,6 +66,15 @@ class StockPicking(models.Model):
             comment += picking.sale_id.note or ''
         if picking.note:
             comment += ' - ' + picking.note
+        fiscal_doc_ref = self._context.get(
+                'fiscal_doc_ref', False)
+
+        if vals.get('type', False) == 'out_refund' and fiscal_doc_ref and fiscal_doc_ref._name == 'account.invoice':
+            result['fiscal_document_related_ids'] = [
+                (0, False,
+                 {'invoice_related_id': fiscal_doc_ref.id,
+                  'document_type': 'nfe',
+                  'access_key': fiscal_doc_ref.nfe_access_key})]
 
         result['partner_shipping_id'] = picking.partner_id.id
 

--- a/l10n_br_stock_account/models/stock_account.py
+++ b/l10n_br_stock_account/models/stock_account.py
@@ -66,15 +66,18 @@ class StockPicking(models.Model):
             comment += picking.sale_id.note or ''
         if picking.note:
             comment += ' - ' + picking.note
-        fiscal_doc_ref = self._context.get(
-                'fiscal_doc_ref', False)
 
-        if vals.get('type', False) == 'out_refund' and fiscal_doc_ref and fiscal_doc_ref._name == 'account.invoice':
+        fiscal_doc_ref = self._context.get('fiscal_doc_ref', False)
+        if vals.get('type', False) == 'out_refund' and fiscal_doc_ref \
+                and fiscal_doc_ref._name == 'account.invoice':
             result['fiscal_document_related_ids'] = [
                 (0, False,
                  {'invoice_related_id': fiscal_doc_ref.id,
                   'document_type': 'nfe',
                   'access_key': fiscal_doc_ref.nfe_access_key})]
+
+        if picking.fiscal_category_id.purpose:
+            result['nfe_purpose'] = picking.fiscal_category_id.purpose
 
         result['partner_shipping_id'] = picking.partner_id.id
 

--- a/l10n_br_stock_account/views/stock_account_view.xml
+++ b/l10n_br_stock_account/views/stock_account_view.xml
@@ -1,31 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
 
-    <data>
+	<data>
+		<record id="l10n_br_stock_account_stock_picking_search" model="ir.ui.view">
+			<field name="model">stock.picking</field>
+			<field name="inherit_id" ref="l10n_br_stock.view_l10n_br_sale_stock_filter"/>
+			<field name="arch" type="xml">
+				<field name="ie" position="after">
+					<field name="fiscal_document_access_key"/>
+				</field>
+			</field>
+		</record>
 
-        <record id="l10n_br_view_picking_form1" model="ir.ui.view">
-            <field name="name">l10n_br_stock.picking.form1</field>
-            <field name="model">stock.picking</field>
-            <field name="inherit_id" ref="account_fiscal_position_rule_stock.account_fiscal_position_rule_stock_view_picking_form"/>
-            <field name="priority">32</field>
-            <field name="arch" type="xml">
-                <field name="fiscal_position" position="replace">
-                </field>
-                <field name="invoice_state" position="replace">
-                    <field name="invoice_state" string="Invoice Control" groups="account.group_account_invoice" />
-                    <field name="fiscal_category_id" attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"/>
-                    <field name="fiscal_position" domain="[('fiscal_category_id', '=', fiscal_category_id)]" attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"/>
-                </field>
-                <field name="partner_id" position="attributes">
-                    <attribute name="context_br">{'fiscal_category_id': fiscal_category_id, 'company_id': company_id}</attribute>
-                </field>
-                <field name="company_id" position="attributes">
-                    <attribute name="context_br">{'fiscal_category_id': fiscal_category_id, 'company_id': company_id}</attribute>
-                </field>
-            </field>
-        </record>
 
-        <record id="l10n_br_view_move_picking_tree" model="ir.ui.view">
+		<record id="l10n_br_view_picking_form1" model="ir.ui.view">
+			<field name="name">l10n_br_stock.picking.form1</field>
+			<field name="model">stock.picking</field>
+			<field name="inherit_id"
+				   ref="account_fiscal_position_rule_stock.account_fiscal_position_rule_stock_view_picking_form"/>
+			<field name="priority">32</field>
+			<field name="arch" type="xml">
+				<field name="fiscal_position" position="replace">
+				</field>
+				<field name="invoice_state" position="replace">
+					<field name="invoice_state" string="Invoice Control" groups="account.group_account_invoice"/>
+					<field name="fiscal_category_id"
+						   attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"/>
+					<field name="fiscal_position" domain="[('fiscal_category_id', '=', fiscal_category_id)]"
+						   attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"/>
+					<field name="fiscal_document_access_key"/>
+				</field>
+				<field name="partner_id" position="attributes">
+					<attribute name="context_br">{'fiscal_category_id': fiscal_category_id, 'company_id': company_id}
+					</attribute>
+				</field>
+				<field name="company_id" position="attributes">
+					<attribute name="context_br">{'fiscal_category_id': fiscal_category_id, 'company_id': company_id}
+					</attribute>
+				</field>
+			</field>
+		</record>
+
+		<record id="l10n_br_view_move_picking_tree" model="ir.ui.view">
             <field name="name">l10n_br_stock.move.tree</field>
             <field name="model">stock.move</field>
             <field name="inherit_id" ref="stock.view_move_picking_form"/>

--- a/l10n_br_stock_account/wizard/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizard/stock_invoice_onshipping.py
@@ -7,15 +7,38 @@ import ast
 from openerp import models, fields, api, _
 from openerp.exceptions import Warning as UserError
 
+FISCAL_DOC_REF = [
+    ('account.invoice', u'Fatura'),
+]
+
 
 class StockInvoiceOnShipping(models.TransientModel):
     _inherit = 'stock.invoice.onshipping'
+
+    @api.multi
+    def _compute_fiscal_doc_ref(self):
+        ref_id = False
+        picking_obj = self.env['stock.picking']
+        for record in picking_obj.browse(
+                self._context.get('active_ids', False)):
+            move = record.move_lines[0]
+            if move.origin_returned_move_id:
+                ref_id = self.env['account.invoice'].search([
+                    ('nfe_access_key', '=',
+                     move.origin_returned_move_id.picking_id.fiscal_document_access_key)
+                ], limit=1).id
+            res = 'account.invoice,%d' % ref_id
+            return res
 
     journal_id = fields.Many2one(
         'account.journal', 'Destination Journal',
         domain="[('type', '=', journal_type)]")
     fiscal_category_journal = fields.Boolean(
         u'Diário da Categoria Fiscal', default=True)
+
+    fiscal_doc_ref = fields.Reference(selection=FISCAL_DOC_REF, readonly=False,
+                                      default=_compute_fiscal_doc_ref,
+                                      string=u'Documento Fiscal Relacionado')
 
     @api.multi
     def open_invoice(self):
@@ -42,6 +65,8 @@ class StockInvoiceOnShipping(models.TransientModel):
             fiscal_document_code = picking.company_id.product_invoice_id.code
             context.update(
                 {'fiscal_document_code': fiscal_document_code})
+            if self.fiscal_doc_ref:
+                context.update({'fiscal_doc_ref': self.fiscal_doc_ref})
             if not journal_id:
                 raise UserError(
                     _('Invalid Journal!'),

--- a/l10n_br_stock_account/wizard/stock_invoice_onshipping_view.xml
+++ b/l10n_br_stock_account/wizard/stock_invoice_onshipping_view.xml
@@ -2,18 +2,19 @@
 <openerp>
     <data>
 
-        <record model="ir.ui.view" id="view_l10n_br_stock_invoice_onshipping">
-            <field name="name">L10n_br_Stock Invoice Onshipping</field>
-            <field name="model">stock.invoice.onshipping</field>
-            <field name="inherit_id" ref="stock_account.view_stock_invoice_onshipping"/>
-            <field name="arch" type="xml">
-                <field name="journal_id" position="replace" >
-                    <field name="fiscal_category_journal" />
-                    <newline/>
-                    <field name="journal_id" attrs="{'required': [('fiscal_category_journal', '=', False)], 'invisible': [('fiscal_category_journal', '=', True)]}" />
-                </field>
-            </field>
-        </record>
+		<record model="ir.ui.view" id="view_l10n_br_stock_invoice_onshipping">
+			<field name="name">L10n_br_Stock Invoice Onshipping</field>
+			<field name="model">stock.invoice.onshipping</field>
+			<field name="inherit_id" ref="stock_account.view_stock_invoice_onshipping"/>
+			<field name="arch" type="xml">
+				<field name="journal_id" position="replace" >
+					<field name="fiscal_category_journal" />
+					<newline/>
+					<field name="journal_id" attrs="{'required': [('fiscal_category_journal', '=', False)], 'invisible': [('fiscal_category_journal', '=', True)]}" />
+					<field name="fiscal_doc_ref" />
+				</field>
+			</field>
+		</record>
 
     </data>
 </openerp>


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

Ocorreu um problema durante o merge das funcionalidades de devolução de vendas


Comportamento atual antes do PR:
--------------------------------
O fluxo não funcionava para devolução de vendas referenciando NFes, pois estava faltando parte do código

Comportamento esperado depois do PR:
------------------------------------

Ao devolver uma mercadoria que tenha uma nota relacionada (NFe ou CFe-SaT), a transferência reversa do picking gerador da venda irá preencher todos os campos necessários na NFe de devolução, sem precisar preencher os documentos relacionados.



- [x] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute