### PR TITLE
update __openerp__.py

### DIFF
--- a/l10n_br_pos/__openerp__.py
+++ b/l10n_br_pos/__openerp__.py
@@ -14,7 +14,7 @@
         'l10n_br_sale_stock',
         'point_of_sale',
         'pos_pricelist',
-        'pos_payment_term',
+        'pos_payment_terminal',
         'nfe_attach',
         'pos_order_picking_link',
         'stock_picking_invoice_link',


### PR DESCRIPTION
[depends]

pos_payment_term --> pos_payment_terminal

Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

- Não acho o módulo pos_payment_term, acredito que seja o pos_payment_terminal

Comportamento atual antes do PR:
--------------------------------
Não Instala o módulo devido à dependência não existir.

Comportamento esperado depois do PR:
------------------------------------
Instala o módulo.




- [X] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute