### PR TITLE
[FIX] Doc relacionado em devolução para fornecedor

### DIFF
--- a/l10n_br_stock_account/models/stock_account.py
+++ b/l10n_br_stock_account/models/stock_account.py
@@ -68,7 +68,7 @@ class StockPicking(models.Model):
             comment += ' - ' + picking.note
 
         fiscal_doc_ref = self._context.get('fiscal_doc_ref', False)
-        if vals.get('type', False) == 'out_refund' and fiscal_doc_ref \
+        if vals.get('type', False).endswith('_refund') and fiscal_doc_ref \
                 and fiscal_doc_ref._name == 'account.invoice':
             result['fiscal_document_related_ids'] = [
                 (0, False,


### PR DESCRIPTION
Copia informação de documento relacionado do picking de devolução
também para fatura ao fornecedor, não apenas para fatura ao cliente.

Descrição do problema/nova funcionalidade deste Pull Resquest (PR):
------------------------------------------------------------------

Faturas criadas a partir de pickings de devolução para fornecedor não preenchiam o campo de `Documentos Relacionados`. Apenas faturas criadas a partir de pickings de devolução de cliente preenciam o campo corretamente.

- [x] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute