### PR TITLE
[ADD] Adiantamento do dia útil de vencimento quando necessário

### DIFF
--- a/financial/__openerp__.py
+++ b/financial/__openerp__.py
@@ -43,6 +43,7 @@
         'wizards/report_xlsx_financial_cashflow_wizard_view.xml',
         'wizards/report_xlsx_financial_moves_states_wizard.xml',
         'views/financial_move_payment_one2many_base_view.xml',
+        'views/res_company.xml',
         'views/financial_move_debt_base_view.xml',
         'views/financial_move_debt_2receive_view.xml',
         'views/financial_move_debt_2pay_view.xml',

--- a/financial/models/__init__.py
+++ b/financial/models/__init__.py
@@ -7,6 +7,7 @@ from . import financial_account
 from . import financial_account_tree_analysis
 from . import financial_document_type
 from . import inherited_res_partner_bank
+from . import res_company
 from . import financial_move
 from . import financial_installment
 from . import financial_installment_simulation

--- a/financial/models/financial_document_type.py
+++ b/financial/models/financial_document_type.py
@@ -22,3 +22,8 @@ class FinancialDocumentType(models.Model):
         string='Account',
         ondelete='restrict',
     )
+
+    adiantar_dia_pagamento_util = fields.Boolean(
+        string=u'Adiantar dia de pagamento útil?',
+        default=False
+    )

--- a/financial/models/res_company.py
+++ b/financial/models/res_company.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 KMEE
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    adiantar_dia_pagamento_util = fields.Boolean(
+        string=u'Adiantar dia de pagamento útil?',
+        default=False
+    )

--- a/financial/views/financial_document_type_view.xml
+++ b/financial/views/financial_document_type_view.xml
@@ -16,6 +16,7 @@
                     <group>
                         <group name="general" colspan="4" col="2">
                             <field name="name" required="1" colspan="2" />
+                            <field name="adiantar_dia_pagamento_util"/>
                         </group>
                     </group>
                 </sheet>

--- a/financial/views/res_company.xml
+++ b/financial/views/res_company.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_financial_res_company_form" model="ir.ui.view">
+            <field name="name">financial.res.company.form</field>
+            <field name="model">res.company</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="arch" type="xml">
+                <page string="Configuration" position="inside">
+                    <group>
+                        <field name="adiantar_dia_pagamento_util"/>
+                    </group>
+                </page>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

- Algumas contas a pagar necessitam ser pagas um dia antes do vencimento no caso do vencimento ser feriado.

Comportamento atual antes do PR:
--------------------------------
Todas as contas a pagar, no caso do vencimento ser feriado, paga a conta no dia seguinte ao vencimento se o vencimento cair em um feriado.

Comportamento esperado depois do PR:
------------------------------------
No tipo de documento e no cadastro da empresa é possível marcar um check box "Adiantar dia útil de pagamento?", que quando acionado faz com que o dia útil de vencimento da movimentação financeira referente à conta a pagar seja um dia antes do dia do vencimento no caso de a conta vencer em um feriado.




- [ ] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute