### PR TITLE
8.0 refactor picking invoice wizard

### DIFF
--- a/l10n_br_pos/models/stock.py
+++ b/l10n_br_pos/models/stock.py
@@ -25,23 +25,3 @@ class StockPicking(models.Model):
         u'Chave de acesso do Documento', compute_sudo=True,
         compute=_get_fiscal_document_access_key,
         store=True)
-
-    @api.model
-    def _create_invoice_from_picking(self, picking, vals):
-        result = {}
-        fiscal_doc_ref = self._context.get(
-                'fiscal_doc_ref', False)
-        if (vals.get('type', False) == 'out_refund' and
-                fiscal_doc_ref and
-                fiscal_doc_ref._name == 'pos.order'):
-            result['fiscal_document_related_ids'] = \
-                [(0, False,
-                  {
-                    'pos_order_related_id': fiscal_doc_ref.id,
-                     'document_type': 'sat',
-                     'access_key': fiscal_doc_ref.chave_cfe[3:]
-                  }
-                  )]
-        vals.update(result)
-        return super(StockPicking, self)._create_invoice_from_picking(
-            picking, vals)

--- a/l10n_br_pos/wizard/stock_invoice_onshipping.py
+++ b/l10n_br_pos/wizard/stock_invoice_onshipping.py
@@ -4,26 +4,23 @@
 
 from openerp import models, fields, api
 
-FISCAL_DOC_REF = [
-    ('pos.order', u'Pedido do PDV')
-]
 
+class StockInvoiceOnShippingRelatedDocument(models.TransientModel):
+    _inherit = 'stock.invoice.onshipping.related.document'
 
-
-class StockInvoiceOnShipping(models.TransientModel):
-    _inherit = 'stock.invoice.onshipping'
-
-    @api.multi
-    def _fiscal_doc_ref_selection(self):
-        prev = super(StockInvoiceOnShipping, self)._fiscal_doc_ref_selection()
-        return prev + FISCAL_DOC_REF
+    @api.model
+    def get_picking_document_relationships(self):
+        return super(
+            StockInvoiceOnShippingRelatedDocument, self
+        ).get_picking_document_relationships() + [
+            'move_lines.origin_returned_move_id.picking_id.pos_order_ids',
+        ]
 
     @api.multi
-    def _fiscal_doc_ref_default(self):
-        result = super(StockInvoiceOnShipping, self)._fiscal_doc_ref_default()
-        id_in_model = result.split(',')[1]
-        if id_in_model == '0':
-            return_picking_ids = self.get_returned_picking_ids()
-            ref_id = return_picking_ids.mapped('pos_order_ids')[:1].id
-            result = 'pos.order,%d' % ref_id
-        return result
+    def compute_all_for_pos_order(self):
+        self.document_type = "sat"
+        document = self.fiscal_doc_ref
+        self.document_date = document.date_order
+        self.document_partner_id = document.partner_id
+        self.document_amount = document.amount_total
+        self.access_key = document.chave_cfe[3:]

--- a/l10n_br_pos/wizard/stock_invoice_onshipping.py
+++ b/l10n_br_pos/wizard/stock_invoice_onshipping.py
@@ -5,7 +5,6 @@
 from openerp import models, fields, api
 
 FISCAL_DOC_REF = [
-    ('account.invoice', u'Fatura'),
     ('pos.order', u'Pedido do PDV')
 ]
 
@@ -15,8 +14,13 @@ class StockInvoiceOnShipping(models.TransientModel):
     _inherit = 'stock.invoice.onshipping'
 
     @api.multi
-    def _compute_fiscal_doc_ref(self):
-        result = super(StockInvoiceOnShipping, self)._compute_fiscal_doc_ref()
+    def _fiscal_doc_ref_selection(self):
+        prev = super(StockInvoiceOnShipping, self)._fiscal_doc_ref_selection()
+        return prev + FISCAL_DOC_REF
+
+    @api.multi
+    def _fiscal_doc_ref_default(self):
+        result = super(StockInvoiceOnShipping, self)._fiscal_doc_ref_default()
         id_in_model = result.split(',')[1]
         if id_in_model != '0':
             return result
@@ -33,8 +37,3 @@ class StockInvoiceOnShipping(models.TransientModel):
                     ], limit=1).id
                     result = 'pos.order,%d' % ref_id
             return result
-
-    fiscal_doc_ref = fields.Reference(selection=FISCAL_DOC_REF,
-                                      readonly=False,
-                                      default=_compute_fiscal_doc_ref,
-                                      string=u'Documento Fiscal Relacionado')

--- a/l10n_br_pos/wizard/stock_invoice_onshipping.py
+++ b/l10n_br_pos/wizard/stock_invoice_onshipping.py
@@ -22,18 +22,8 @@ class StockInvoiceOnShipping(models.TransientModel):
     def _fiscal_doc_ref_default(self):
         result = super(StockInvoiceOnShipping, self)._fiscal_doc_ref_default()
         id_in_model = result.split(',')[1]
-        if id_in_model != '0':
-            return result
-        else:
-            picking_obj = self.env['stock.picking']
-            for record in picking_obj.browse(
-                    self._context.get('active_ids', False)):
-                move = record.move_lines[0]
-                if move.origin_returned_move_id:
-                    ref_id = self.env['pos.order'].search([
-                        ('chave_cfe', '=',
-                         move.origin_returned_move_id.
-                         picking_id.fiscal_document_access_key)
-                    ], limit=1).id
-                    result = 'pos.order,%d' % ref_id
-            return result
+        if id_in_model == '0':
+            return_picking_ids = self.get_returned_picking_ids()
+            ref_id = return_picking_ids.mapped('pos_order_ids')[:1].id
+            result = 'pos.order,%d' % ref_id
+        return result

--- a/l10n_br_stock_account/models/stock_account.py
+++ b/l10n_br_stock_account/models/stock_account.py
@@ -67,14 +67,15 @@ class StockPicking(models.Model):
         if picking.note:
             comment += ' - ' + picking.note
 
-        fiscal_doc_ref = self._context.get('fiscal_doc_ref', False)
-        if vals.get('type', False).endswith('_refund') and fiscal_doc_ref \
-                and fiscal_doc_ref._name == 'account.invoice':
+        related_fiscal_documents = self.env.context.get(
+            'related_fiscal_documents', ()
+        )
+        if (vals.get('type', False).endswith('_refund') and
+                related_fiscal_documents):
             result['fiscal_document_related_ids'] = [
-                (0, False,
-                 {'invoice_related_id': fiscal_doc_ref.id,
-                  'document_type': 'nfe',
-                  'access_key': fiscal_doc_ref.nfe_access_key})]
+                (0, False, related_fiscal_document)
+                for related_fiscal_document in related_fiscal_documents
+            ]
 
         if picking.fiscal_category_id.purpose:
             result['nfe_purpose'] = picking.fiscal_category_id.purpose

--- a/l10n_br_stock_account/wizard/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizard/stock_invoice_onshipping.py
@@ -7,47 +7,121 @@ import ast
 from openerp import models, fields, api, _
 from openerp.exceptions import Warning as UserError
 
-FISCAL_DOC_REF = [
-    ('account.invoice', u'Fatura'),
-]
+
+class StockInvoiceOnShippingRelatedDocument(models.TransientModel):
+    _name = 'stock.invoice.onshipping.related.document'
+
+    origin_id = fields.Many2one(
+        ondelete='cascade',
+        comodel_name='stock.invoice.onshipping',
+    )
+
+    fiscal_doc_ref = fields.Reference(
+        selection="_fiscal_doc_ref_selection",
+        readonly=False,
+        required=True,
+        string=u'Documento Fiscal',
+    )
+
+    document_model = fields.Char(
+        string=u"Tipo de Documento",
+        compute="compute_all",
+    )
+
+    document_type = fields.Char(compute="compute_all")
+
+    document_date = fields.Datetime(
+        string=u"Data",
+        compute="compute_all"
+    )
+
+    document_partner_id = fields.Many2one(
+        string=u"Parceiro",
+        comodel_name='res.partner',
+        compute="compute_all"
+    )
+
+    document_amount = fields.Char(
+        string=u"Valor",
+        compute="compute_all",
+    )
+
+    access_key = fields.Char(compute="compute_all")
+
+    @api.multi
+    @api.depends("fiscal_doc_ref")
+    def compute_all(self):
+        model_map = dict(self._fiscal_doc_ref_selection())
+        for record in self:
+            if not record.fiscal_doc_ref:
+                continue
+            record.document_model = model_map[record.fiscal_doc_ref._name]
+            method_name = "compute_all_for_" + record.fiscal_doc_ref._table
+            getattr(record, method_name)()
+
+    @api.multi
+    def compute_all_for_account_invoice(self):
+        self.document_type = "nfe"
+        document = self.fiscal_doc_ref
+        self.document_date = document.date_invoice
+        self.document_partner_id = document.partner_id
+        self.document_amount = document.amount_total
+        self.access_key = document.nfe_access_key
+
+    @api.model
+    def get_picking_document_relationships(self):
+        return [
+            'move_lines.origin_returned_move_id.picking_id.invoice_ids',
+        ]
+
+    @api.multi
+    def _fiscal_doc_ref_selection(self):
+        model_names = [
+            self.env['stock.picking'].mapped(relationship)._name
+            for relationship in self.get_picking_document_relationships()
+        ]
+        selection = [
+            (record['model'], record['display_name'])
+            for record in self.env['ir.model'].search(
+                [('model', 'in', model_names)]
+            )
+        ]
+        return selection
+
+    @api.model
+    def create_for_picking_ids(self, pickings):
+        result = self.browse()
+        for relationship in self.get_picking_document_relationships():
+            for record in pickings.mapped(relationship):
+                item = self.create(dict(
+                    fiscal_doc_ref="{record._name},{record.id}".format(
+                        record=record
+                    )
+                ))
+                result |= item
+        # Why is this needed? Apparently the compute_all() method is not being
+        # called on the .create() above :-(
+        item.compute_all()
+        return result
 
 
 class StockInvoiceOnShipping(models.TransientModel):
     _inherit = 'stock.invoice.onshipping'
 
-    @api.multi
-    def _fiscal_doc_ref_selection(self):
-        return FISCAL_DOC_REF
-
-    @api.multi
-    def _compute_fiscal_doc_ref(self):
-        """
-        Delegate calculation of fiscal_doc_ref default.
-
-        A string argument to fields.Reference(default=...) is interpreted as
-        the actual default value instead of method to look up the default.
-
-        Here we delegate to self._fiscal_doc_ref_default() so inheriting models
-        can override it.
-        """
-        return self._fiscal_doc_ref_default()
-
     def active_picking_ids(self):
         context = self.env.context
         return self.env['stock.picking'].browse(context.get('active_ids'))
 
-    @api.model
-    def get_returned_picking_ids(self):
-        return self.active_picking_ids().mapped(
-            'move_lines.origin_returned_move_id.picking_id'
-        )
-
     @api.multi
-    def _fiscal_doc_ref_default(self):
-        return_picking_ids = self.get_returned_picking_ids()
-        ref_id = return_picking_ids.mapped('invoice_ids')[:1].id
-        res = 'account.invoice,%d' % ref_id
-        return res
+    def _related_document_ids_default(self):
+        picking_ids = self.active_picking_ids()
+        related = self.env['stock.invoice.onshipping.related.document']
+        related = related.create_for_picking_ids(picking_ids)
+        # Do not return `related` directly since `.origin_id` is `False`
+        # and self.id is False during `.default_get()` on the browser UI.
+        # Instead, we have to return the One2many commands for creating them.
+        result = [(0, None, vals) for vals in related.read()]
+        return result
 
     journal_id = fields.Many2one(
         'account.journal', 'Destination Journal',
@@ -55,10 +129,12 @@ class StockInvoiceOnShipping(models.TransientModel):
     fiscal_category_journal = fields.Boolean(
         u'Diário da Categoria Fiscal', default=True)
 
-    fiscal_doc_ref = fields.Reference(selection="_fiscal_doc_ref_selection",
-                                      readonly=False,
-                                      default=_compute_fiscal_doc_ref,
-                                      string=u'Documento Fiscal Relacionado')
+    related_document_ids = fields.One2many(
+        string=u'Related Documents',
+        comodel_name='stock.invoice.onshipping.related.document',
+        inverse_name='origin_id',
+        default=_related_document_ids_default,
+    )
 
     @api.multi
     def open_invoice(self):
@@ -77,6 +153,18 @@ class StockInvoiceOnShipping(models.TransientModel):
         return result
 
     @api.multi
+    def _get_related_fiscal_documents(self):
+        self.ensure_one()
+        return [
+            dict(
+                invoice_related_id=related_documents.fiscal_doc_ref.id,
+                document_type=related_documents.document_type,
+                access_key=related_documents.access_key,
+            )
+            for related_documents in self.related_document_ids
+        ]
+
+    @api.multi
     def create_invoice(self):
         self.ensure_one()
         context = dict(self.env.context)
@@ -93,9 +181,9 @@ class StockInvoiceOnShipping(models.TransientModel):
             context).fiscal_category_id.property_journal
         fiscal_document_code = picking.company_id.product_invoice_id.code
         context.update(
-            {'fiscal_document_code': fiscal_document_code})
-        if self.fiscal_doc_ref:
-            context.update({'fiscal_doc_ref': self.fiscal_doc_ref})
+            fiscal_document_code=fiscal_document_code,
+            related_fiscal_documents=self._get_related_fiscal_documents(),
+        )
         if not journal_id:
             raise UserError(
                 _('Invalid Journal!'),

--- a/l10n_br_stock_account/wizard/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizard/stock_invoice_onshipping.py
@@ -16,7 +16,24 @@ class StockInvoiceOnShipping(models.TransientModel):
     _inherit = 'stock.invoice.onshipping'
 
     @api.multi
+    def _fiscal_doc_ref_selection(self):
+        return FISCAL_DOC_REF
+
+    @api.multi
     def _compute_fiscal_doc_ref(self):
+        """
+        Delegate calculation of fiscal_doc_ref default.
+
+        A string argument to fields.Reference(default=...) is interpreted as
+        the actual default value instead of method to look up the default.
+
+        Here we delegate to self._fiscal_doc_ref_default() so inheriting models
+        can override it.
+        """
+        return self._fiscal_doc_ref_default()
+
+    @api.multi
+    def _fiscal_doc_ref_default(self):
         ref_id = False
         picking_obj = self.env['stock.picking']
         for record in picking_obj.browse(
@@ -37,7 +54,8 @@ class StockInvoiceOnShipping(models.TransientModel):
     fiscal_category_journal = fields.Boolean(
         u'Diário da Categoria Fiscal', default=True)
 
-    fiscal_doc_ref = fields.Reference(selection=FISCAL_DOC_REF, readonly=False,
+    fiscal_doc_ref = fields.Reference(selection="_fiscal_doc_ref_selection",
+                                      readonly=False,
                                       default=_compute_fiscal_doc_ref,
                                       string=u'Documento Fiscal Relacionado')
 

--- a/l10n_br_stock_account/wizard/stock_invoice_onshipping_view.xml
+++ b/l10n_br_stock_account/wizard/stock_invoice_onshipping_view.xml
@@ -11,8 +11,20 @@
 					<field name="fiscal_category_journal" />
 					<newline/>
 					<field name="journal_id" attrs="{'required': [('fiscal_category_journal', '=', False)], 'invisible': [('fiscal_category_journal', '=', True)]}" />
-					<field name="fiscal_doc_ref" />
 				</field>
+                <xpath expr="footer" position="before">
+                    <group string="Documentos Fiscais Relacionados" cols="1">
+                        <field nolabel="1" name="related_document_ids">
+                            <tree editable="bottom">
+                                <field name="fiscal_doc_ref"/>
+                                <field name="document_model"/>
+                                <field name="document_date"/>
+                                <field name="document_partner_id"/>
+                                <field name="document_amount"/>
+                            </tree>
+                        </field>
+                    </group>
+                </xpath>
 			</field>
 		</record>
 


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------

Este PR simplifica a maneira como o wizard de criação de faturas a partir de pickings localiza os documentos relacionados.

Este PR visa preparar o caminho para uma modificação deste wizard que permita uma única fatura relacionar vários documentos (outras faturas ou pos.orders).

Comportamento atual antes do PR:
--------------------------------

Os invoices e pos.orders relacionados eram buscados via chave de acesso e o código era bem mais rebuscado

Comportamento esperado depois do PR:
------------------------------------

Os invoices e pos.orders são buscado diretamente por relacionamentos, em código que é bem mais simples de compreender.

- [x] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute