### PR TITLE
[10.0] Campo para indicar a presença do comprador

### DIFF
--- a/sped_imposto/models/inherited_sped_empresa.py
+++ b/sped_imposto/models/inherited_sped_empresa.py
@@ -202,6 +202,20 @@ class SpedEmpresa(models.Model):
         string='Último lote de RPS'
     )
 
+    default_ind_pres = fields.Selection(
+        selection=[
+            ('0', 'Não se aplica'),
+            ('1', 'Operação presencial'),
+            ('2', 'Operação não presencial, pela Internet'),
+            ('3', 'Operação não presencial, Teleatendimento'),
+            ('4', 'NFC-e em operação com entrega em domicílio'),
+            ('9', 'Operação não presencial, otros'),
+        ],
+        string='Tipo de operação',
+        help='Indicador de presença do comprador no '
+             '\nestabelecimento comercial no momento da operação.',
+    )
+
     @api.depends('simples_anexo_id', 'simples_anexo_servico_id',
                  'simples_teto_id')
     def _compute_simples_aliquota_id(self):

--- a/sped_imposto/models/inherited_sped_empresa.py
+++ b/sped_imposto/models/inherited_sped_empresa.py
@@ -202,7 +202,7 @@ class SpedEmpresa(models.Model):
         string='Último lote de RPS'
     )
 
-    default_ind_pres = fields.Selection(
+    ind_pres = fields.Selection(
         selection=[
             ('0', 'Não se aplica'),
             ('1', 'Operação presencial'),

--- a/sped_imposto/models/sped_calculo_imposto.py
+++ b/sped_imposto/models/sped_calculo_imposto.py
@@ -347,6 +347,25 @@ class SpedCalculoImposto(SpedBase):
     #     copy=True,
     # )
 
+    ind_pres = fields.Selection(
+        selection=[
+            ('0', 'Não se aplica'),
+            ('1', 'Operação presencial'),
+            ('2', 'Operação não presencial, pela Internet'),
+            ('3', 'Operação não presencial, Teleatendimento'),
+            ('4', 'NFC-e em operação com entrega em domicílio'),
+            ('9', 'Operação não presencial, outros')
+        ],
+        string='Tipo de operação',
+        readonly=True,
+        states={'draft': [('readonly', False)]},
+        required=False,
+        help='Indicador de presença do comprador no estabelecimento '
+             'comercial no momento da operação.',
+        default=lambda
+            self: self.env.user.company_id.sped_empresa_id.default_ind_pres,
+    )
+
     @api.depends('company_id', 'partner_id')
     def _compute_is_brazilian(self):
         for documento in self:

--- a/sped_imposto/models/sped_calculo_imposto.py
+++ b/sped_imposto/models/sped_calculo_imposto.py
@@ -363,7 +363,7 @@ class SpedCalculoImposto(SpedBase):
         help='Indicador de presença do comprador no estabelecimento '
              'comercial no momento da operação.',
         default=lambda
-            self: self.env.user.company_id.sped_empresa_id.default_ind_pres,
+            self: self.env.user.company_id.sped_empresa_id.ind_pres,
     )
 
     @api.depends('company_id', 'partner_id')

--- a/sped_imposto/views/inherited_sped_empresa_view.xml
+++ b/sped_imposto/views/inherited_sped_empresa_view.xml
@@ -34,6 +34,7 @@
                         <field name="operacao_produto_id" string="Venda" colspan="4" options="{'no_open': True, 'no_create': True}" />
                         <field name="operacao_produto_pessoa_fisica_id" string="Venda pessoa física" colspan="4" options="{'no_open': True, 'no_create': True}" />
                         <field name="operacao_produto_ids" string="Outras operações permitidas" colspan="4" widget="many2many_tags" />
+                        <field name="default_ind_pres" colspan="4"/>
                         <separator string="Operações Fiscais padrão para serviços" colspan="4" />
                         <field name="operacao_servico_id" string="Venda" colspan="4" options="{'no_open': True, 'no_create': True}" />
                         <field name="operacao_servico_ids" sring="Outras operações permitidas" colspan="4" widget="many2many_tags" />

--- a/sped_imposto/views/inherited_sped_empresa_view.xml
+++ b/sped_imposto/views/inherited_sped_empresa_view.xml
@@ -34,7 +34,7 @@
                         <field name="operacao_produto_id" string="Venda" colspan="4" options="{'no_open': True, 'no_create': True}" />
                         <field name="operacao_produto_pessoa_fisica_id" string="Venda pessoa física" colspan="4" options="{'no_open': True, 'no_create': True}" />
                         <field name="operacao_produto_ids" string="Outras operações permitidas" colspan="4" widget="many2many_tags" />
-                        <field name="default_ind_pres" colspan="4"/>
+                        <field name="ind_pres" colspan="4"/>
                         <separator string="Operações Fiscais padrão para serviços" colspan="4" />
                         <field name="operacao_servico_id" string="Venda" colspan="4" options="{'no_open': True, 'no_create': True}" />
                         <field name="operacao_servico_ids" sring="Outras operações permitidas" colspan="4" widget="many2many_tags" />

--- a/sped_sale/views/sale_order.xml
+++ b/sped_sale/views/sale_order.xml
@@ -89,6 +89,7 @@
                             <field name="partner_shipping_id"/>
                             <field name="date_order" />
                             <field name="pricelist_id" groups="product.group_sale_pricelist"/>
+                            <field name="ind_pres" />
                         </group>
                     </group>
 


### PR DESCRIPTION
Descrição do problema/nova funcionalidade deste Pull Resquest(PR):
------------------------------------------------------------------
Campo para indicar o tipo de presença do comprador (internet/televendas/presencial/etc)
- Campo foi adicionado na classe abstrata SpedCalculoImposto. Para estar presente em outras operações.
- Nesse PR foi adicionado apenas na view de venda.
-

Comportamento atual antes do PR:
--------------------------------


Comportamento esperado depois do PR:
------------------------------------





- [ ] Esta mudança não altera a estrutura do banco de dados, portanto não precisa de script de migração.

--
Eu confirmo que eu assinei a CLA e li as recomendações de como contribuir:
- https://odoo-community.org/page/cla
- https://odoo-community.org/page/Contribute