### PR TITLE
[FIX] Para a API nova o parametro valor espera o tipo number

### DIFF
--- a/l10n_br_account/sped/ibpt/deolhonoimposto.py
+++ b/l10n_br_account/sped/ibpt/deolhonoimposto.py
@@ -42,7 +42,7 @@ def _request(req):
 
 
 def get_ibpt_product(config, ncm, ex='0', reference=None, description=None,
-                     uom=None, amount=None, gtin=None):
+                     uom=None, amount=0, gtin=None):
 
     data = urllib.urlencode({
         'token': config.token,


### PR DESCRIPTION
Na API nova o parametro: 'valor' espera o tipo: 'number'