### PR TITLE
[FIX] teste 6 com erro de data

### DIFF
--- a/l10n_br_resource/tests/test_resource_calendar.py
+++ b/l10n_br_resource/tests/test_resource_calendar.py
@@ -129,7 +129,7 @@ class TestResourceCalendar(test_common.SingleTransactionCase):
         proximo_dia_util = self.municipal_calendar_id.proximo_dia_util(
             anterior_ao_fds)
         self.assertEqual(proximo_dia_util,
-                         fields.Datetime.from_string('2016-12-19 00:00:01'),
+                         fields.Datetime.from_string('2016-12-16 00:00:01'),
                          'Partindo de um fds, próximo dia util inválido')
 
     def test_07_get_dias_base(self):


### PR DESCRIPTION
No teste 6 do método proximo_dia_util quando se passa uma data, ele primeiramente compara a data com ela mesmo e se a data que ele escolheu for dia útil, ele retorna que o próximo dia útil é aquele dia. Na minha percepção ela deveria começar a comparação com o próximo dia útil e não o dia em questão.

Ex: se eu quiser saber qual próximo dia útil passando como parâmetro dia 2016-12-16, que é uma sexta-feira, deveria retornar dia 19, mas o código retorna dia 16, pois no método quando ele faz as comparações ele compara primeiramente 16 e não com 17. 