### PR TITLE
[FIX] The method to get the next useful day need to add one day befor…

### DIFF
--- a/l10n_br_resource/models/inherited_resource_calendar.py
+++ b/l10n_br_resource/models/inherited_resource_calendar.py
@@ -195,9 +195,9 @@ class ResourceCalendar(models.Model):
         :return datetime Proximo dia util apartir da data referencia
         """
         while data_referencia:
+            data_referencia += timedelta(days=1)
             if self.data_eh_dia_util(data_referencia):
                 return data_referencia
-            data_referencia += timedelta(days=1)
 
     @api.multi
     def proximo_dia_util_bancario(self, data_referencia=datetime.now()):


### PR DESCRIPTION
@mbcosta:
O método que verifica o próximo dia útil estava verificando inicialmente a data recebida o que causava erro porque se data fosse um dia útil retornava ela mesma ao invés do próximo dia útil.

@atillaSilva  

