### PR TITLE
Chave do CFe gera o pos.order name

### DIFF
--- a/l10n_br_pos/__openerp__.py
+++ b/l10n_br_pos/__openerp__.py
@@ -21,6 +21,9 @@
         'stock_picking_invoice_link',
         'l10n_br_stock_account',
     ],
+    "external_dependencies": {
+        "python": ['satcomum'],
+    },
     'data': [
         "wizard/l10n_br_pos_order_return.xml",
         "views/pos_template.xml",

--- a/l10n_br_pos/models/__init__.py
+++ b/l10n_br_pos/models/__init__.py
@@ -10,3 +10,4 @@ from . import l10n_br_account_product
 from . import stock
 from . import res_partner
 from . import stock_move
+from . import ir_sequence

--- a/l10n_br_pos/models/ir_sequence.py
+++ b/l10n_br_pos/models/ir_sequence.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# © 2016 KMEE INFORMATICA LTDA (https://kmee.com.br)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+from openerp.exceptions import Warning as UserError
+
+
+class IrSequence(models.Model):
+    _inherit = 'ir.sequence'
+
+    @api.multi
+    def _interpolate_value(self, value):
+        self.ensure_one()
+        d = self._interpolation_dict_context(context=self.env.context)
+        try:
+            prefix = self._interpolate(self.prefix, d)
+            suffix = self._interpolate(self.suffix, d)
+        except ValueError:
+            raise UserError(_('Invalid prefix or suffix for sequence \'%s\'') %
+                            (seq.get('name'),))
+        return "{prefix}{value:0>{padding}}{suffix}".format(
+            value=value, prefix=prefix, suffix=suffix, padding=self.padding,
+        )

--- a/l10n_br_pos/models/pos_order.py
+++ b/l10n_br_pos/models/pos_order.py
@@ -4,6 +4,8 @@
 
 import time
 
+from satcomum.ersat import ChaveCFeSAT
+
 from openerp import models, fields, api
 from openerp.addons import decimal_precision as dp
 from openerp.tools.float_utils import float_compare
@@ -99,6 +101,14 @@ class PosOrder(models.Model):
     @api.model
     def create(self, vals):
         order = super(PosOrder, self).create(vals)
+        pos_config = order.session_id.config_id
+        if pos_config.iface_sat_via_proxy:
+            sequence = pos_config.sequence_id
+            cfe = ChaveCFeSAT('CFe' + vals['chave_cfe'])
+            order.name = sequence._interpolate_value("%s / %s" % (
+                cfe.numero_serie,
+                cfe.numero_cupom_fiscal,
+            ))
         order.simplified_limit_check()
         return order
 
@@ -238,11 +248,6 @@ class PosOrder(models.Model):
         }
 
         return dados_reimpressao
-
-    @api.model
-    def get_sequence_name(self, session_id):
-        session = self.env['pos.session'].browse(session_id)
-        return session.config_id.sequence_id.number_next_actual
 
 
 class PosOrderLine(models.Model):

--- a/l10n_br_pos/static/src/js/models.js
+++ b/l10n_br_pos/static/src/js/models.js
@@ -285,7 +285,7 @@ function l10n_br_pos_models(instance, module) {
                 result['configs_sat']['cod_ativacao'] = pos_config.cod_ativacao;
                 result['configs_sat']['impressora'] = pos_config.impressora;
                 result['configs_sat']['printer_params'] = pos_config.printer_params;
-                result['informacoes_adicionais'] = '';
+                result['informacoes_adicionais'] = pos_config.company_id[1];
 
                 return result;
             }else{

--- a/l10n_br_pos/static/src/js/screens.js
+++ b/l10n_br_pos/static/src/js/screens.js
@@ -471,24 +471,12 @@ function l10n_br_pos_screens(instance, module) {
                             this.pos_widget.action_bar.set_button_disabled('validation',true);
                             var receipt = currentOrder.export_for_printing();
                             var json = currentOrder.export_for_printing();
-                            if (self.pos.config.enviar_pedido_cupom_fiscal) {
-                                new instance.web.Model('pos.order').call('get_sequence_name', [this.pos.pos_session.id]).then(function (order_name) {
-                                    json['informacoes_adicionais'] = order_name;
-                                    self.pos.proxy.send_order_sat(
-                                        currentOrder,
-                                        QWeb.render('XmlReceipt',{
-                                        receipt: receipt, widget: self,
-                                    }), json);
-                                    self.pos.get('selectedOrder').destroy();
-                                });
-                            } else {
-                                self.pos.proxy.send_order_sat(
+                            self.pos.proxy.send_order_sat(
                                     currentOrder,
                                     QWeb.render('XmlReceipt',{
                                     receipt: receipt, widget: self,
                                 }), json);
                                 self.pos.get('selectedOrder').destroy();
-                            }
                         }else{
                             this.pos.push_order(currentOrder);
                         }


### PR DESCRIPTION
[ADD] Chave do CFe gera o pos.order name

- é criada a associação entre o nome da loja configurado no pos.config e
 os valores do número do sat e o número da venda retirados da chave do
 cupom fiscal após o retorno da SEFAZ.