### PR TITLE
[FIX] Corrige a lentidão na confirmação da invoice:

### DIFF
--- a/l10n_br_pos/models/stock.py
+++ b/l10n_br_pos/models/stock.py
@@ -22,6 +22,7 @@ class StockPicking(models.Model):
                 or pos_order_access_key[0] or '')
 
     fiscal_document_access_key = fields.Char(
-        u'Chave de acesso do Documento', compute_sudo=True,
+        u'Chave de acesso do Documento',
+        compute_sudo=True,
         compute=_get_fiscal_document_access_key,
-        store=True)
+    )

--- a/l10n_br_stock_account/models/stock_account.py
+++ b/l10n_br_stock_account/models/stock_account.py
@@ -30,7 +30,8 @@ class StockPicking(models.Model):
         readonly=True, states={'draft': [('readonly', False)]})
     fiscal_document_access_key = fields.Char(
         u'Chave de acesso do Documento',
-        compute=_get_fiscal_document_access_key, store=True)
+        # compute=_get_fiscal_document_access_key
+    )
 
     def _fiscal_position_map(self, result, **kwargs):
         ctx = dict(self.env.context)


### PR DESCRIPTION
O campo fiscal_document_access_key dependia de um campo calculado com store false invoice_id.

A abordagem mais simples foi tornar o campo fiscal_document_access_key com store false para reduzir o numero de calculos durante o processo de confirmação da invoice.

Caso seja preciso aumentar o ainda mais o desempenho existem outras abordagens possíveis.