### PR TITLE
Para de guardar no db `stock.picking:fiscal_document_access_key`

### DIFF
--- a/l10n_br_pos/__openerp__.py
+++ b/l10n_br_pos/__openerp__.py
@@ -12,6 +12,7 @@
     "category": "Point Of Sale",
     "depends": [
         'l10n_br_sale_stock',
+        'l10n_br_stock_account',
         'point_of_sale',
         'pos_pricelist',
         'pos_payment_term',

--- a/l10n_br_pos/models/stock.py
+++ b/l10n_br_pos/models/stock.py
@@ -8,20 +8,9 @@ from openerp import models, fields, api
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
-    @api.multi
-    @api.depends('invoice_id.nfe_access_key',
-                 'invoice_ids.nfe_access_key',
-                 'pos_order_ids.chave_cfe')
-    def _get_fiscal_document_access_key(self):
-        for picking in self:
-            pos_order_access_key = [order.chave_cfe
-                                    for order in picking.pos_order_ids
-                                    if picking.pos_order_ids] or ['']
-            picking.fiscal_document_access_key = (
-                (picking.invoice_id and picking.invoice_id.nfe_access_key)
-                or pos_order_access_key[0] or '')
-
-    fiscal_document_access_key = fields.Char(
-        u'Chave de acesso do Documento', compute_sudo=True,
-        compute=_get_fiscal_document_access_key,
-        store=True)
+    @api.model
+    def _get_fiscal_document_access_keys_fields(self):
+        su = super(StockPicking, self)
+        return su._get_fiscal_document_access_keys_fields() + [
+            'pos_order_ids.chave_cfe'
+        ]

--- a/l10n_br_stock_account/models/stock_account.py
+++ b/l10n_br_stock_account/models/stock_account.py
@@ -2,7 +2,13 @@
 # Copyright (C) 2014  Renato Lima - Akretion
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import itertools
+
 from openerp import models, fields, api
+
+
+def _get_fiscal_document_access_keys_depends(model):
+    return model._get_fiscal_document_access_keys_fields()
 
 
 class StockPicking(models.Model):
@@ -12,12 +18,33 @@ class StockPicking(models.Model):
     def _default_fiscal_category(self):
         return self.env.user.company_id.stock_fiscal_category_id
 
+    @api.model
+    def _get_fiscal_document_access_keys_fields(self):
+        return ['invoice_ids.nfe_access_key']
+
     @api.multi
-    @api.depends('invoice_id.nfe_access_key')
-    def _get_fiscal_document_access_key(self):
+    @api.depends(_get_fiscal_document_access_keys_depends)
+    def _get_fiscal_document_access_keys(self):
+        """
+        Concatenates all valid access keys in all dependent fields
+        """
+        mapped_fields = self._get_fiscal_document_access_keys_fields()
         for picking in self:
-            picking.fiscal_document_access_key = \
-                picking.invoice_id.nfe_access_key if picking.invoice_id else ''
+            keys = sorted(set(filter(None, itertools.chain(*[
+                picking.mapped(field) for field in mapped_fields
+            ]))))
+            picking.fiscal_document_access_keys = '\n'.join(keys)
+            picking.fiscal_document_access_key = (keys + [False])[0]
+
+    def _search_fiscal_document_access_keys(self, operator, value):
+        """
+        Search in all access_key fields
+        """
+        subdomain = [
+            (field, operator, value)
+            for field in self._get_fiscal_document_access_keys_fields()
+        ]
+        return ['|'] * (len(subdomain) - 1) + subdomain
 
     fiscal_category_id = fields.Many2one(
         'l10n_br_account.fiscal.category', 'Categoria Fiscal',
@@ -30,7 +57,19 @@ class StockPicking(models.Model):
         readonly=True, states={'draft': [('readonly', False)]})
     fiscal_document_access_key = fields.Char(
         u'Chave de acesso do Documento',
-        compute=_get_fiscal_document_access_key, store=True)
+        help=('Backward Compatibility field. Please use '
+              '"fiscal_document_access_keys"'),
+        compute="_get_fiscal_document_access_keys",
+        compute_sudo=True,
+        search="_search_fiscal_document_access_keys",
+    )
+    fiscal_document_access_keys = fields.Text(
+        u'Chaves de acesso',
+        help=u'Chaves de acesso dos documentos relacionados',
+        compute="_get_fiscal_document_access_keys",
+        compute_sudo=True,
+        search="_search_fiscal_document_access_keys",
+    )
 
     def _fiscal_position_map(self, result, **kwargs):
         ctx = dict(self.env.context)

--- a/l10n_br_stock_account/views/stock_account_view.xml
+++ b/l10n_br_stock_account/views/stock_account_view.xml
@@ -7,7 +7,7 @@
 			<field name="inherit_id" ref="l10n_br_stock.view_l10n_br_sale_stock_filter"/>
 			<field name="arch" type="xml">
 				<field name="ie" position="after">
-					<field name="fiscal_document_access_key"/>
+					<field name="fiscal_document_access_keys"/>
 				</field>
 			</field>
 		</record>
@@ -28,7 +28,7 @@
 						   attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"/>
 					<field name="fiscal_position" domain="[('fiscal_category_id', '=', fiscal_category_id)]"
 						   attrs="{'invisible': [('invoice_state', '=', 'none')], 'required': [('invoice_state', '=', '2binvoiced')], 'readonly': [('invoice_state', '=', 'invoiced')]}"/>
-					<field name="fiscal_document_access_key"/>
+					<field name="fiscal_document_access_keys"/>
 				</field>
 				<field name="partner_id" position="attributes">
 					<attribute name="context_br">{'fiscal_category_id': fiscal_category_id, 'company_id': company_id}


### PR DESCRIPTION
Para de guardar no db `stock.picking:fiscal_document_access_key`.

Torna quais documentos fornecem access_key plugável por subclasses.