### PR TITLE
[ADD]Aba de aquisições incluida

### DIFF
--- a/l10n_br_base/models/sped_produto.py
+++ b/l10n_br_base/models/sped_produto.py
@@ -171,6 +171,22 @@ class SpedProduto(SpedBase, models.Model):
         size=20,
     )
 
+    #Aba de aquisições
+    codigo_produto_fornecedor = fields.Char(
+        string='Código do produto no fornecedor',
+    )
+    descricao_produto = fields.Char(
+        string='Descrição do produto',
+    )
+    preco = fields.Monetary(
+        string='Preço',
+    )
+    fornecedor = fields.Many2one(
+        comodel_name='sped.participante',
+        string='Fornecedor',
+        domain=[['eh_fornecedor', '=', True]],
+    )
+
 
     @api.depends('ncm_id', 'unidade_id')
     def _compute_exige_fator_conversao_ncm(self):

--- a/l10n_br_base/views/sped_produto_base_view.xml
+++ b/l10n_br_base/views/sped_produto_base_view.xml
@@ -66,6 +66,14 @@
                                 <field name="fator_quantidade_especie" />
                             </group>
                         </page>
+                        <page name="estoque" string="Aquisições">
+                            <group col="4">
+                                <field name="fornecedor"/>
+                                <field name="codigo_produto_fornecedor"/>
+                                <field name="descricao_produto"/>
+                                <field name="preco"/>
+                            </group>
+                        </page>
                     </notebook>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
Inclusão da aba de aquisições no cadastro de produtos. 

" Euro - Aba "Aquisições" no cadastro de produtos (Preciso daqueles campos que permitem cadastrar o fornecedor, código do produto no fornecedor, descrição do fornecedor e preço.)" -> https://docs.google.com/a/kmee.com.br/document/d/101721bCpypstZqIwgFA7RtpjtyDRU6SdBaWzCe3CRwU/edit?usp=sharing