### PR TITLE
[REM] Rotinas desnecessarias do financeiro

### DIFF
--- a/sped_finan/models/inherited_sped_documento.py
+++ b/sped_finan/models/inherited_sped_documento.py
@@ -92,8 +92,6 @@ class SpedDocumento(models.Model):
 
     def executa_depois_autorizar(self):
         super(SpedDocumento, self).executa_depois_autorizar()
-        self.exclui_finan_lancamento()
-        self.gera_finan_lancamento()
 
     def executa_depois_cancelar(self):
         super(SpedDocumento, self).executa_depois_cancelar()


### PR DESCRIPTION
No documento fiscal quando a nota for autorizada, nao eh necessário recriar toda  a movimentação financeira.