### PR TITLE
[IMP] Ajustando a necessidade de cadastro do contribuinte

### DIFF
--- a/l10n_br_base/models/sped_participante.py
+++ b/l10n_br_base/models/sped_participante.py
@@ -221,7 +221,6 @@ class SpedParticipante(SpedBase, models.Model):
     contribuinte = fields.Selection(
         selection=INDICADOR_IE_DESTINATARIO,
         string='Contribuinte',
-        required = True ,
     )
     ie = fields.Char(
         string='Inscrição estadual',

--- a/l10n_br_base/views/sped_participante_base_view.xml
+++ b/l10n_br_base/views/sped_participante_base_view.xml
@@ -63,7 +63,7 @@
                         <group col="4">
                             <group col="4" colspan="4">
                                 <separator string="Inscrição Estadual" colspan="4" />
-                                <field name="contribuinte" colspan="2" />
+                                <field name="contribuinte" colspan="2" attrs="{'required': [('exige_cnpj_cpf', '=', True)]}" />
                                 <field name="ie" attrs="{'invisible': [('contribuinte', '!=', '1')], 'required': [('contribuinte', '=', '1')]}" colspan="2" />
                             </group>
                             <newline />


### PR DESCRIPTION
No cadastro de um sped.participante o campo do contribuinte nao precisa ser obrigatorio quando se tratar de um consumidor final.
Se nao for consumidor final, o cadastro do campo deve ser obrigatório.

Cenário 1: não obrigatório
Cadastro > cliente > novo
Aba fiscal setar o campo "é consumidor final?"
Campo nao deve ser obrigatorio

Cenário 2: obrigatório
Cadastro > cliente > novo
Campo deve ser obrigatorio