### PR TITLE
[FIX]Visibilidade de botões da conciliação bancaria

### DIFF
--- a/finan/views/finan_remessa_boleto_view.xml
+++ b/finan/views/finan_remessa_boleto_view.xml
@@ -12,7 +12,7 @@
         <field name="arch" type="xml">
             <form string="Remessa de Boletos">
                 <header>
-                    <button name="gera_arquivo" string="Gera arquivo" class="btn-primary" type="object" groups="finan.GRUPO_CADASTRO_GERAL, finan.GRUPO_CADASTRO_GERENTE"/>
+                    <button name="gera_arquivo" string="Gera arquivo" class="btn-primary" type="object" groups="finan.GRUPO_CADASTRO_GERAL"/>
                 </header>
                 <sheet>
                     <group col="4" colspan="4">

--- a/finan/views/finan_remessa_boleto_view.xml
+++ b/finan/views/finan_remessa_boleto_view.xml
@@ -12,7 +12,7 @@
         <field name="arch" type="xml">
             <form string="Remessa de Boletos">
                 <header>
-                    <button name="gera_arquivo" string="Gera arquivo" class="btn-primary" type="object" />
+                    <button name="gera_arquivo" string="Gera arquivo" class="btn-primary" type="object" groups="finan.GRUPO_CADASTRO_GERAL, finan.GRUPO_CADASTRO_GERENTE"/>
                 </header>
                 <sheet>
                     <group col="4" colspan="4">

--- a/finan/views/finan_retorno_boleto_view.xml
+++ b/finan/views/finan_retorno_boleto_view.xml
@@ -12,7 +12,7 @@
         <field name="arch" type="xml">
             <form string="Retorno de Boletos">
                 <header>
-                    <button name="processar_retorno" string="Processar" class="btn-primary" type="object" groups="finan.GRUPO_CADASTRO_GERAL, finan.GRUPO_CADASTRO_GERENTE"/>
+                    <button name="processar_retorno" string="Processar" class="btn-primary" type="object" groups="finan.GRUPO_CADASTRO_GERAL"/>
                 </header>
                 <sheet>
                     <group col="4" colspan="4">

--- a/finan/views/finan_retorno_boleto_view.xml
+++ b/finan/views/finan_retorno_boleto_view.xml
@@ -12,7 +12,7 @@
         <field name="arch" type="xml">
             <form string="Retorno de Boletos">
                 <header>
-                    <button name="processar_retorno" string="Processar" class="btn-primary" type="object" />
+                    <button name="processar_retorno" string="Processar" class="btn-primary" type="object" groups="finan.GRUPO_CADASTRO_GERAL, finan.GRUPO_CADASTRO_GERENTE"/>
                 </header>
                 <sheet>
                     <group col="4" colspan="4">


### PR DESCRIPTION
Adicionar permissão ao Botão de processamento do retorno do CNAB.
Adicionar permissão ao Botão de processamento da remessa do CNAB.
Apenas operadores do financeiro podem ver os botões.



  