### PR TITLE
[ADD]Adição de warning em remessa de boletos

### DIFF
--- a/finan/models/finan_remessa.py
+++ b/finan/models/finan_remessa.py
@@ -9,6 +9,7 @@ from odoo.addons.l10n_br_base.models.sped_base import SpedBase
 from ..constantes import *
 
 from pybrasil.febraban import *
+from odoo.exceptions import UserError
 
 
 class FinanRemessa(SpedBase, models.Model):
@@ -61,14 +62,17 @@ class FinanRemessa(SpedBase, models.Model):
             boleto = lancamento.gera_boleto(sem_anexo=True)
             boletos.append(boleto)
 
-        remessa = RemessaBoleto()
-        #remessa.tipo = 'CNAB_400'
-        #remessa.tipo = 'CNAB_240'
-        remessa.boletos = boletos
-        remessa.sequencia = self.numero
-        remessa.data_hora = self.data + ' UTC'
+        if boletos:
+            remessa = RemessaBoleto()
+            #remessa.tipo = 'CNAB_400'
+            #remessa.tipo = 'CNAB_240'
+            remessa.boletos = boletos
+            remessa.sequencia = self.numero
+            remessa.data_hora = self.data + ' UTC'
 
-        self._grava_anexo(
-            nome_arquivo=remessa.nome_arquivo,
-            conteudo=remessa.arquivo_remessa
-        )
+            self._grava_anexo(
+                nome_arquivo=remessa.nome_arquivo,
+                conteudo=remessa.arquivo_remessa
+            )
+        else:
+            raise UserError('É preciso adicionar boletos para gerar um arquivo.')

--- a/finan/views/finan_remessa_boleto_view.xml
+++ b/finan/views/finan_remessa_boleto_view.xml
@@ -12,7 +12,7 @@
         <field name="arch" type="xml">
             <form string="Remessa de Boletos">
                 <header>
-                    <button name="gera_arquivo" string="Gera arquivo" class="btn-primary" type="object" groups="finan.GRUPO_CADASTRO_GERAL"/>
+                    <button name="gera_arquivo" string="Gera arquivo" class="btn-primary" type="object" groups="finan.GRUPO_CADASTRO_GERAL" attrs="{'invisible': [('lancamento_ids', '=', False)]}"/>
                 </header>
                 <sheet>
                     <group col="4" colspan="4">

--- a/finan/views/finan_retorno_boleto_view.xml
+++ b/finan/views/finan_retorno_boleto_view.xml
@@ -12,7 +12,7 @@
         <field name="arch" type="xml">
             <form string="Retorno de Boletos">
                 <header>
-                    <button name="processar_retorno" string="Processar" class="btn-primary" type="object" groups="finan.GRUPO_CADASTRO_GERAL"/>
+                    <button name="processar_retorno" string="Processar" class="btn-primary" type="object" attrs="{'invisible': [('arquivo_binario', '=', False)]}" groups="finan.GRUPO_CADASTRO_GERAL"/>
                 </header>
                 <sheet>
                     <group col="4" colspan="4">


### PR DESCRIPTION
Adição de warning caso o usuário tente clicar em Gerar arquivo sem ter adicionado boletos, ao invés de aparecer um erro de index, aparece o warning com a mensagem "É preciso adicionar boletos para gerar um arquivo."