### PR TITLE
[FIX] Correção na amostragem de campos CST e CFOP em lista de itens

### DIFF
--- a/sped/models/sped_documento_item.py
+++ b/sped/models/sped_documento_item.py
@@ -174,6 +174,42 @@ class SpedDocumentoItem(SpedCalculoImpostoItem, models.Model):
         compute='_compute_permite_alteracao',
     )
 
+    cst_icms_readonly = fields.Char(
+        string='CST ICMS',
+        compute='_sync_cst_icms',
+    )
+
+    @api.depends('cst_icms')
+    def _sync_cst_icms(self):
+        for item in self:
+            if not item.cst_icms:
+                continue
+            item.cst_icms_readonly = item.cst_icms
+
+    cst_pis_readonly = fields.Char(
+        string='CST PIS',
+        compute='_sync_cst_pis',
+    )
+
+    @api.depends('cst_pis')
+    def _sync_cst_pis(self):
+        for item in self:
+            if not item.cst_pis:
+                continue
+            item.cst_pis_readonly = item.cst_pis
+
+    cst_cofins_readonly = fields.Char(
+        string='CST COFINS',
+        compute='_sync_cst_cofins',
+    )
+
+    @api.depends('cst_cofins')
+    def _sync_cst_cofins(self):
+        for item in self:
+            if not item.cst_cofins:
+                continue
+            item.cst_cofins_readonly = item.cst_cofins
+
     @api.depends('modelo', 'emissao')
     def _compute_permite_alteracao(self):
         for item in self:

--- a/sped/views/sped_documento_base_view.xml
+++ b/sped/views/sped_documento_base_view.xml
@@ -94,7 +94,7 @@
                         <page name="itens" string="Itens">
                             <group>
                                 <group colspan="4" col="4">
-                                    <field name="item_ids" nolabel="1" colspan="4" attrs="{'readonly': [('permite_alteracao', '=', False)]}" />
+                                    <field name="item_ids" nolabel="1" colspan="4" attrs="{'readonly': [('permite_alteracao', '=', False)]}"/>
                                 </group>
                             </group>
                         </page>

--- a/sped/views/sped_documento_emissao_nfe_view.xml
+++ b/sped/views/sped_documento_emissao_nfe_view.xml
@@ -18,7 +18,7 @@
             <xpath expr="//separator[@name='pagamentos']" position="replace" />
             <xpath expr="//field[@name='pagamento_ids']" position="replace" />
             <field name="item_ids" position="attributes" >
-                <attribute name="context">{'form_view_ref' : 'sped.sped_documento_item_emissao_form', 'tree_view_ref' : 'sped.sped_documento_item_emissao_tree'}</attribute>
+                <attribute name="context">{'cfop_tam_desc': 'curta', 'form_view_ref' : 'sped.sped_documento_item_emissao_form', 'tree_view_ref' : 'sped.sped_documento_item_emissao_tree'}</attribute>
             </field>
         </field>
     </record>

--- a/sped/views/sped_documento_item_base_view.xml
+++ b/sped/views/sped_documento_item_base_view.xml
@@ -403,8 +403,11 @@
                 <field name="currency_unidade_id" invisible="1"/>
                 <field name="unidade_id" invisible="1"/>
                 <field name="produto_id"  />
-                <field name="cfop_id"  />
-                <field name="quantidade"  />
+                <field name="cfop_id"/>
+                <field name="cst_icms_readonly" string="ICMS"/>
+                <field name="cst_pis_readonly" string="PIS"/>
+                <field name="cst_cofins_readonly" string="COFINS"/>
+                <field name="quantidade"/>
                 <field name="vr_unitario"  />
                 <field name="vr_produtos" sum="vr_produtos"/>
                 <field name="org_icms" invisible="[('modelo', 'in', ('SE', 'RL'))]"/>

--- a/sped/views/sped_documento_recebimento_nfe_view.xml
+++ b/sped/views/sped_documento_recebimento_nfe_view.xml
@@ -18,7 +18,7 @@
             <xpath expr="//separator[@name='pagamentos']" position="replace" />
             <xpath expr="//field[@name='pagamento_ids']" position="replace" />
             <field name="item_ids" position="attributes" >
-                <attribute name="context">{'form_view_ref' : 'sped.sped_documento_item_emissao_form', 'tree_view_ref' : 'sped.sped_documento_item_emissao_tree', 'manual': True}</attribute>
+                <attribute name="context">{'cfop_tam_desc': 'curta', 'form_view_ref' : 'sped.sped_documento_item_emissao_form', 'tree_view_ref' : 'sped.sped_documento_item_emissao_tree', 'manual': True}</attribute>
             </field>
             <field name="entrada_saida" position="attributes" >
                 <attribute name="attrs">{'invisible': False}</attribute>

--- a/sped_imposto/models/sped_cfop.py
+++ b/sped_imposto/models/sped_cfop.py
@@ -184,7 +184,10 @@ class SpedCFOP(models.Model):
         res = []
 
         for cfop in self:
-            res.append((cfop.id, cfop.codigo + ' - ' + cfop.descricao))
+            if self._context.get('cfop_tam_desc') == 'curta':
+                res.append((cfop.id, cfop.codigo))
+            else:
+                res.append((cfop.id, cfop.codigo + ' - ' + cfop.descricao))
 
         return res
 

--- a/sped_purchase/views/sped_documento_emissao_nfe_view.xml
+++ b/sped_purchase/views/sped_documento_emissao_nfe_view.xml
@@ -12,6 +12,7 @@
             </group>
             <field name="item_ids" position="attributes">
                 <attribute name="context">{
+                    'cfop_tam_desc': 'curta',
                     'form_view_ref' : 'sped_purchase.sped_documento_item_form',
                     'tree_view_ref' : 'sped_purchase.sped_documento_item_tree',
                     'manual': True}</attribute>


### PR DESCRIPTION
Corrige os campos de CST e CFOP, mostrando apenas seu código na tree view dos itens do documento.