### PR TITLE
[FIX][IMP] Busca de finan_conta_id nas operações de emissão\recebimento

### DIFF
--- a/sped_finan/models/inherited_sped_documento.py
+++ b/sped_finan/models/inherited_sped_documento.py
@@ -131,12 +131,9 @@ class SpedDocumento(models.Model):
                               "para os CFOPs dos itens importados.")
                         )
                 except:
-                    raise UserError(
-                        _("É preciso definir uma operação com uma conta para "
-                          "os CFOPs dos itens importados")
-                    )
+                    continue
 
-        documento.duplicata_ids.gera_lancamento_financeiro()
+            documento.duplicata_ids.gera_lancamento_financeiro()
 
     def _busca_operacao(self):
         '''


### PR DESCRIPTION
Quando uma NF-e é importada, caso o sped_finan esteja instalado, ao calcular o valor da NF é chamado um @OnChange que tenta gerar um finan_lancamento dentro de um 'executa_depois_create'.

O problema é que ao se criar um finan_lancamento, ele espera que a NF-e tenha uma finan_conta associada. O que não é possível.

Fiz da seguinte maneira: as informações de conta a serem preenchidas serão buscadas nas operações de emissão\recebimento de acordo com o CFOP dos itens da NF-e importada. 

Mas daí gera outra dúvida, existem NF-e que não devem gerar finan_lancamento ao serem importadas.. talvez de acordo com CFOP, não sei.  Eu devo já tratar isso agora? Como devo proceder?