### PR TITLE
[FIX] Modelagem dos documentos subsequentes

### DIFF
--- a/sped_imposto/models/sped_operacao_subsequente.py
+++ b/sped_imposto/models/sped_operacao_subsequente.py
@@ -61,27 +61,3 @@ class SpedOperacaoSubsequente(models.Model):
     referenciar_documento = fields.Boolean(
         string="Refenciar documento de origem",
     )
-
-    @api.multi
-    def _confirma_geracao(self, documento):
-        """ Dado um documento fiscal verificamos se podemos gerar a operação
-        :param documento:
-        :return: True permitindo a geração
-        """
-        result = False
-
-        if self.situacao_geracao in [x for x, y in SITUACAO_SUBSEQUENTE]:
-            cupom = documento.filtered(lambda documento: documento.modelo in (
-                MODELO_FISCAL_CFE,
-                MODELO_FISCAL_NFCE,
-                MODELO_FISCAL_CUPOM_FISCAL_ECF,
-            ))
-            if cupom and self.situacao_geracao == 'nota_de_cupom':
-                result = True
-            elif self.situacao_geracao == 'manual' and self.env.context.get('manual', False):
-                result = True
-            elif self.situacao_geracao == 'nota_de_remessa':
-                result = True
-        elif documento.situacao_nfe == self.situacao_geracao:
-            result = True
-        return result

--- a/sped_queue/model/__init__.py
+++ b/sped_queue/model/__init__.py
@@ -5,3 +5,4 @@
 from . import sped_operacao
 from . import sped_documento
 from . import sped_operacao_subsequente
+from . import sped_documento_subsequente

--- a/sped_queue/model/sped_documento.py
+++ b/sped_queue/model/sped_documento.py
@@ -37,29 +37,6 @@ class SpedDocumento(models.Model):
                          enviar_depois.ids)
             enviar_depois.with_delay()._envia_documento_job()
 
-    @api.multi
-    @job
-    def _gera_operacoes_subsequentes_job(self):
-        for record in self:
-            record._gera_operacoes_subsequentes()
-
-    @api.multi
-    def gera_operacoes_subsequentes(self):
-        _logger.info('Gerando documento fiscal %s', self.ids)
-
-        gerar_agora = self.filtered(
-            lambda documento: documento.operacao_id.operacao_subsequente_ids.gerar_documento == 'now'
-        )
-        gerar_depois = self - gerar_agora
-        if gerar_agora:
-            _logger.info('Gerando documento fiscal agora: %s',
-                         gerar_agora.ids)
-            gerar_agora._gera_operacoes_subsequentes_job()
-        if gerar_depois:
-            _logger.info('Gerando documento fiscal depois: %s',
-                         gerar_depois.ids)
-            gerar_depois.with_delay()._gera_operacoes_subsequentes_job()
-
     def _envia_email_job(self, mail_template):
         self.with_delay()._envia_email(mail_template)
 

--- a/sped_queue/model/sped_documento_subsequente.py
+++ b/sped_queue/model/sped_documento_subsequente.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 KMEE INFORMATICA LTDA
+#   Gabriel Cardoso de Faria <gabriel.cardoso@kmee.com.br>
+# License AGPL-3 or later (http://www.gnu.org/licenses/agpl)
+#
+
+from __future__ import division, print_function, unicode_literals
+from odoo import api, fields, models, _
+from odoo.addons.queue_job.job import job
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class SpedDocumentoSubsequente(models.Model):
+    _inherit = b'sped.documento.subsequente'
+
+    @api.multi
+    @job
+    def _gera_documento_subsequente_job(self):
+        self._gera_documento_subsequente()
+
+    @api.multi
+    def gera_documento_subsequente(self):
+        _logger.info('Gerando documento fiscal %s', self.ids)
+
+        if self.operacao_subsequente_id.gerar_documento == 'now':
+            _logger.info('Gerando documento fiscal agora: %s',
+                         self.documento_origem_id.ids)
+            self._gera_documento_subsequente_job()
+        else:
+            _logger.info('Gerando documento fiscal depois: %s',
+                         self.documento_origem_id.ids)
+            self.with_delay()._gera_documento_subsequente_job()


### PR DESCRIPTION
Refatoração na modelagem dos sped.documento.subsequente:
 - Validação e decisão de gerar ou não o documento subsequente (sped.documento -> sped.documento.subsequente);
 - Módulo sped_queue herda função gera_documento_subsequente(em sped.documento.subsequente) e decide se criar ou não um job;
 - Função gera_operacoes_subsequentes(em sped.documento) manda o comando de criação para todos os sped.documento.subsequente no campo documento_subsequente_ids.