### PR TITLE
[REF] Consulta de nf-e já enviada

### DIFF
--- a/sped_nfe/models/inherited_sped_documento.py
+++ b/sped_nfe/models/inherited_sped_documento.py
@@ -515,13 +515,17 @@ class SpedDocumento(models.Model):
             if processo.resposta.cStat.valor in ('100', '150'):
                 self.chave = processo.resposta.chNFe.valor
 
-                if not self.protocolo_autorizacao:
+                if not (
+                            self.protocolo_autorizacao or
+                            self.arquivo_xml_autorizacao_id
+                        ):
+
                     consulta = processador.consultar_nota(
                         processador.ambiente,
                         self.chave,
                         nfe,
                     )
-                    if nfe.procNFe:
+                    if nfe.procNFe and consulta:
                         procNFe = nfe.procNFe
                         self.grava_xml(procNFe.NFe)
                         self.grava_xml_autorizacao(procNFe)
@@ -544,6 +548,7 @@ class SpedDocumento(models.Model):
                 self.executa_antes_autorizar()
                 self.situacao_nfe = SITUACAO_NFE_AUTORIZADA
                 self.executa_depois_autorizar()
+
             elif processo.resposta.cStat.valor in ('110', '301', '302'):
                 self.chave = processo.resposta.chNFe.valor
                 self.executa_antes_denegar()

--- a/sped_nfe/models/inherited_sped_documento.py
+++ b/sped_nfe/models/inherited_sped_documento.py
@@ -514,6 +514,33 @@ class SpedDocumento(models.Model):
         elif processo.webservice == WS_NFE_CONSULTA:
             if processo.resposta.cStat.valor in ('100', '150'):
                 self.chave = processo.resposta.chNFe.valor
+
+                if not self.protocolo_autorizacao:
+                    consulta = processador.consultar_nota(
+                        processador.ambiente,
+                        self.chave,
+                        nfe,
+                    )
+                    if nfe.procNFe:
+                        procNFe = nfe.procNFe
+                        self.grava_xml(procNFe.NFe)
+                        self.grava_xml_autorizacao(procNFe)
+
+                        if self.modelo == MODELO_FISCAL_NFE:
+                            res = self.grava_pdf(nfe, procNFe.danfe_pdf)
+                        elif self.modelo == MODELO_FISCAL_NFCE:
+                            res = self.grava_pdf(nfe, procNFe.danfce_pdf)
+
+                        data_autorizacao = \
+                            consulta.resposta.protNFe.infProt.dhRecbto.valor
+                        data_autorizacao = UTC.normalize(data_autorizacao)
+
+                        self.data_hora_autorizacao = data_autorizacao
+                        self.protocolo_autorizacao = \
+                            consulta.resposta.protNFe.infProt.nProt.valor
+                        self.chave = \
+                            consulta.resposta.protNFe.infProt.chNFe.valor
+
                 self.executa_antes_autorizar()
                 self.situacao_nfe = SITUACAO_NFE_AUTORIZADA
                 self.executa_depois_autorizar()

--- a/sped_nfe/views/inherited_sped_documento_emissao_nfce_view.xml
+++ b/sped_nfe/views/inherited_sped_documento_emissao_nfce_view.xml
@@ -14,6 +14,8 @@
             <header position="inside">
                 <button name="envia_documento" string="Enviar NFC-e" type="object" class="btn-primary"
                     attrs="{'invisible': [('situacao_nfe', 'not in', ['em_digitacao', 'rejeitada'])]}" />
+                <button name="envia_documento" string="Consultar NFC-e" type="object"
+                            attrs="{'invisible': [('situacao_nfe', 'not in', ['autorizada'])]}"/>
                 <button name="envia_email_nfe" string="Enviar email" type="object" class="btn-primary" />
                 <button name="imprimir_documento" string="Imprimir" type="object" class="btn-default"/>
                 <button name="gera_xml" string="Visualiza XML" type="object" class="btn-default"/>

--- a/sped_nfe/views/inherited_sped_documento_emissao_nfe_view.xml
+++ b/sped_nfe/views/inherited_sped_documento_emissao_nfe_view.xml
@@ -15,6 +15,8 @@
 
                     <button name="envia_documento" string="Enviar NF-e" type="object" class="btn-primary"
                         attrs="{'invisible': [('situacao_nfe', 'not in', ['em_digitacao', 'a_enviar', 'rejeitada'])]}" />
+                    <button name="envia_documento" string="Consultar NF-e" type="object"
+                            attrs="{'invisible': [('situacao_nfe', 'not in', ['autorizada'])]}"/>
                     <button name="envia_email_nfe" string="Enviar email" type="object" class="btn-primary" />
                     <button name="imprimir_documento" string="Imprimir" type="object" class="btn-default" />
                     <button name="gera_xml" string="Visualiza XML" type="object" class="btn-default" />


### PR DESCRIPTION
Permite a consulta de nf-e em caso de falha na comunicação com o SEFAZ onde o protocolo e o xml de retorno não foram recebidos.

Estava estruturando uma mudança mais elegante no pysped, mas isto vai ficar para uma segunda hora.