### PR TITLE
Importação de NF-e cancelada

### DIFF
--- a/sped_nfe/models/sped_importa_nfe.py
+++ b/sped_nfe/models/sped_importa_nfe.py
@@ -83,7 +83,7 @@ class ImportaNFe(models.Model):
 
 
             documento.justificativa = nfe.evento.infEvento.detEvento.xJust
-            self.protocolo_cancelamento = nfe.retEvento.infEvento.nProt
+            documento.protocolo_cancelamento = nfe.retEvento.infEvento.nProt
 
             # TODO: data_hora_cancelamento
             # self.data_hora_cancelamento = \

--- a/sped_nfe/models/sped_importa_nfe.py
+++ b/sped_nfe/models/sped_importa_nfe.py
@@ -91,7 +91,7 @@ class ImportaNFe(models.Model):
                 except Exception as e:
                     if 'Nenhum documento encontrado' in (e.message or e.name):
                         arquivos_cancelamento.append(filename)
-                    print u"Exception:  " + filename
+                    _logger.error(u"Exception: " + filename)
 
         self.quantidade_diretorio = 0
         self.quantidade_importada = 0

--- a/sped_nfe/models/sped_importa_nfe.py
+++ b/sped_nfe/models/sped_importa_nfe.py
@@ -20,6 +20,8 @@ from odoo.exceptions import UserError
 import logging
 import threading
 from pybrasil.data import UTC
+import dateutil.parser
+
 from odoo.addons.l10n_br_base.constante_tributaria import (
     SITUACAO_FISCAL_CANCELADO,
     SITUACAO_NFE_CANCELADA,
@@ -85,9 +87,11 @@ class ImportaNFe(models.Model):
             documento.justificativa = nfe.evento.infEvento.detEvento.xJust
             documento.protocolo_cancelamento = nfe.retEvento.infEvento.nProt
 
-            # TODO: data_hora_cancelamento
-            # self.data_hora_cancelamento = \
-            #     nfe.retEvento.infEvento.dhRegEvento
+            data_cancelamento = dateutil.parser.parse(
+                nfe.retEvento.infEvento.dhRegEvento.text)
+            data_cancelamento = UTC.normalize(data_cancelamento)
+
+            documento.data_hora_cancelamento = data_cancelamento
 
             documento.situacao_fiscal = SITUACAO_FISCAL_CANCELADO
             documento.situacao_nfe = SITUACAO_NFE_CANCELADA

--- a/sped_nfe/models/sped_importa_nfe.py
+++ b/sped_nfe/models/sped_importa_nfe.py
@@ -90,21 +90,21 @@ class ImportaNFe(models.Model):
                         self.env.cr.commit()
                 except Exception as e:
                     if 'Nenhum documento encontrado' in (e.message or e.name):
-                        arquivos_cancelamento.append(filename)
+                        arquivos_eventos.append(filename)
                     _logger.error(u"Exception: " + filename)
 
         self.quantidade_diretorio = 0
         self.quantidade_importada = 0
 
-        arquivos_cancelamento = []
+        arquivos_eventos = []
 
         percorre_arquivos()
 
         '''Se existirem arquivos de cancelamento de NF-e, eles devem ser 
         processados depois do processamento de todos os outros arquivos'''
-        if arquivos_cancelamento:
-            self.quantidade_diretorio -= len(arquivos_cancelamento)
-            percorre_arquivos(arquivos_cancelamento[:])
+        if arquivos_eventos:
+            self.quantidade_diretorio -= len(arquivos_eventos)
+            percorre_arquivos(arquivos_eventos[:])
 
 
     # def _importar_caminho(self, diretorio):

--- a/sped_purchase/wizard/sped_consulta_status_documento.py
+++ b/sped_purchase/wizard/sped_consulta_status_documento.py
@@ -112,6 +112,28 @@ class SpedConsultaStatusDocumento(models.TransientModel):
             xml = base64.b64decode(self.arquivo)
 
             nfe = objectify.fromstring(xml)
+
+            if('procEventoNFe' in nfe.tag):
+                if(nfe.evento.infEvento.detEvento.
+                        descEvento == 'Cancelamento'):
+
+                    documentos = self.env['sped.importa.nfe'].\
+                        importa_nfe_cancelada(xml)
+
+                    if documentos:
+                        return {
+                            'name': _("NF-e Cancelada"),
+                            'view_mode': 'form',
+                            'view_type': 'form',
+                            'view_id': self.env.ref(
+                                'sped_nfe.sped_documento_ajuste_recebimento_form').id,
+                            'res_id': documentos[0].id,
+                            'res_model': 'sped.documento',
+                            'type': 'ir.actions.act_window',
+                            'target': 'current',
+                            'flags': {'form': {'action_buttons': True}},
+                        }
+
             documento = self.env['sped.documento'].new()
             documento.modelo = nfe.NFe.infNFe.ide.mod.text
             dados = documento.le_nfe(xml=xml)

--- a/sped_purchase/wizard/sped_consulta_status_documento.py
+++ b/sped_purchase/wizard/sped_consulta_status_documento.py
@@ -117,7 +117,7 @@ class SpedConsultaStatusDocumento(models.TransientModel):
                 if(nfe.evento.infEvento.detEvento.
                         descEvento == 'Cancelamento'):
 
-                    documentos = self.env['sped.importa.nfe'].\
+                    documentos = self.env['sped.documento'].\
                         importa_nfe_cancelada(xml)
 
                     if documentos:


### PR DESCRIPTION
O que funciona:
- Importação apenas do XML do cancelamento da NF-e (tendo o documento já importado) pelo wizard 'Consultar Documento'
- Importação de uma pasta contendo diversos arquivos, entre eles o XML de cancelamento (submenu Importa NF-e)

O campo 'data_hora_cancelamento' ficou como pendente, faltando fazer sua conversão de String no formato ISO para fields.Datetime