### PR TITLE
[FIX]Valor Operação corrigido

### DIFF
--- a/sped_imposto/models/sped_calculo_imposto_item.py
+++ b/sped_imposto/models/sped_calculo_imposto_item.py
@@ -2073,7 +2073,7 @@ class SpedCalculoImpostoItem(SpedBase):
         #
         # Calcula o valor dos produtos
         #
-        vr_produtos = D(self.quantidade) * D(self.vr_unitario)
+        vr_produtos = D(self.quantidade) * D(self.produto_id.preco_venda)
         vr_produtos = vr_produtos.quantize(D('0.01'))
 
         #if self.al_desconto:


### PR DESCRIPTION
O campo valor operação estava sendo preenchido com um valor diferente do esperado. 
O problema era que o onchange calculava o preço do produto e subtraia a taxa administrativa dele, colocando como valor unitário do produto essa subtração, quando o valor unitario deveria ser o valor do produto. 