### PR TITLE
Semana 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ addon | version | summary
 [l10n_br_account](l10n_br_account/) | 12.0.4.4.0 | Brazilian Localization Account
 [l10n_br_account_bank_statement_import_cnab](l10n_br_account_bank_statement_import_cnab/) | 12.0.1.0.0 | Importação de Extrato Bancário CNAB 240 - Segmento E
 [l10n_br_account_payment_order](l10n_br_account_payment_order/) | 12.0.1.0.0 | Brazilian Payment Order
-[l10n_br_base](l10n_br_base/) | 12.0.2.1.0 | Customization of base module for implementations in Brazil.
+[l10n_br_base](l10n_br_base/) | 12.0.2.2.0 | Customization of base module for implementations in Brazil.
 [l10n_br_coa](l10n_br_coa/) | 12.0.2.2.0 | Base Brasilian Localization for the Chart of Accounts
 [l10n_br_coa_complete](l10n_br_coa_complete/) | 12.0.1.0.0 | Plano de Contas Completo para empresas Simples, Presumido, Real, SA, Consolidação
 [l10n_br_coa_generic](l10n_br_coa_generic/) | 12.0.2.2.0 | Plano de Contas para empresas do Regime normal (Micro e pequenas empresas)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ addon | version | summary
 [l10n_br_crm](l10n_br_crm/) | 12.0.1.0.0 | Brazilian Localization CRM
 [l10n_br_currency_rate_update](l10n_br_currency_rate_update/) | 12.0.1.0.0 | Update exchange rates using OCA modules for Brazil
 [l10n_br_delivery](l10n_br_delivery/) | 12.0.3.0.0 | This module changes the delivery model strategy to match brazilian standards.
-[l10n_br_fiscal](l10n_br_fiscal/) | 12.0.11.1.1 | Brazilian fiscal core module.
+[l10n_br_fiscal](l10n_br_fiscal/) | 12.0.11.2.0 | Brazilian fiscal core module.
 [l10n_br_hr](l10n_br_hr/) | 12.0.1.0.0 | Brazilian Localization HR
 [l10n_br_hr_contract](l10n_br_hr_contract/) | 12.0.1.1.0 | Brazilian Localization HR Contract
 [l10n_br_mis_report](l10n_br_mis_report/) | 12.0.1.1.0 | Templates de relatórios contábeis brasileiros: Balanço Patrimonial e DRE

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ addon | version | summary
 [l10n_br_crm](l10n_br_crm/) | 12.0.1.0.0 | Brazilian Localization CRM
 [l10n_br_currency_rate_update](l10n_br_currency_rate_update/) | 12.0.1.0.0 | Update exchange rates using OCA modules for Brazil
 [l10n_br_delivery](l10n_br_delivery/) | 12.0.3.0.0 | This module changes the delivery model strategy to match brazilian standards.
-[l10n_br_fiscal](l10n_br_fiscal/) | 12.0.11.1.0 | Brazilian fiscal core module.
+[l10n_br_fiscal](l10n_br_fiscal/) | 12.0.11.1.1 | Brazilian fiscal core module.
 [l10n_br_hr](l10n_br_hr/) | 12.0.1.0.0 | Brazilian Localization HR
 [l10n_br_hr_contract](l10n_br_hr_contract/) | 12.0.1.1.0 | Brazilian Localization HR Contract
 [l10n_br_mis_report](l10n_br_mis_report/) | 12.0.1.1.0 | Templates de relatórios contábeis brasileiros: Balanço Patrimonial e DRE

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ addon | version | summary
 [l10n_br_hr](l10n_br_hr/) | 12.0.1.0.0 | Brazilian Localization HR
 [l10n_br_hr_contract](l10n_br_hr_contract/) | 12.0.1.1.0 | Brazilian Localization HR Contract
 [l10n_br_mis_report](l10n_br_mis_report/) | 12.0.1.1.0 | Templates de relatórios contábeis brasileiros: Balanço Patrimonial e DRE
-[l10n_br_nfe](l10n_br_nfe/) | 12.0.1.3.0 | Brazilian Eletronic Invoice NF-e .
+[l10n_br_nfe](l10n_br_nfe/) | 12.0.1.3.1 | Brazilian Eletronic Invoice NF-e .
 [l10n_br_nfe_spec](l10n_br_nfe_spec/) | 12.0.1.0.0 | nfe spec
 [l10n_br_nfse](l10n_br_nfse/) | 12.0.3.1.0 | NFS-e
 [l10n_br_nfse_ginfes](l10n_br_nfse_ginfes/) | 12.0.2.0.0 | NFS-e (Ginfes)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ addon | version | summary
 [l10n_br_hr](l10n_br_hr/) | 12.0.1.0.0 | Brazilian Localization HR
 [l10n_br_hr_contract](l10n_br_hr_contract/) | 12.0.1.1.0 | Brazilian Localization HR Contract
 [l10n_br_mis_report](l10n_br_mis_report/) | 12.0.1.1.0 | Templates de relatórios contábeis brasileiros: Balanço Patrimonial e DRE
-[l10n_br_nfe](l10n_br_nfe/) | 12.0.1.2.0 | Brazilian Eletronic Invoice NF-e .
+[l10n_br_nfe](l10n_br_nfe/) | 12.0.1.3.0 | Brazilian Eletronic Invoice NF-e .
 [l10n_br_nfe_spec](l10n_br_nfe_spec/) | 12.0.1.0.0 | nfe spec
 [l10n_br_nfse](l10n_br_nfse/) | 12.0.3.1.0 | NFS-e
 [l10n_br_nfse_ginfes](l10n_br_nfse_ginfes/) | 12.0.2.0.0 | NFS-e (Ginfes)

--- a/l10n_br_base/__manifest__.py
+++ b/l10n_br_base/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "author": "Akretion,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-brazil",
-    "version": "12.0.2.1.0",
+    "version": "12.0.2.2.0",
     "depends": ["base", "base_setup", "base_address_city", "base_address_extended"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_br_base/i18n/l10n_br_base.pot
+++ b/l10n_br_base/i18n/l10n_br_base.pot
@@ -6110,7 +6110,6 @@ msgid "City of Address"
 msgstr ""
 
 #. module: l10n_br_base
-#: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_partner_form
 #: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_res_partner_address
 msgid "City..."
 msgstr ""
@@ -6338,7 +6337,6 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_br_base
-#: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_partner_form
 #: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_res_partner_address
 msgid "Complement..."
 msgstr ""
@@ -6944,7 +6942,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_br_base.field_res_company__country_id
 #: model:ir.model.fields,field_description:l10n_br_base.field_res_partner__country_id
 #: model:ir.model.fields,field_description:l10n_br_base.field_res_users__country_id
-#: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_partner_form
 msgid "Country"
 msgstr ""
 
@@ -7717,7 +7714,6 @@ msgid "District"
 msgstr ""
 
 #. module: l10n_br_base
-#: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_partner_form
 #: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_res_partner_address
 msgid "District..."
 msgstr ""
@@ -16835,11 +16831,6 @@ msgid "Novorizonte"
 msgstr ""
 
 #. module: l10n_br_base
-#: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_partner_form
-msgid "Number..."
-msgstr ""
-
-#. module: l10n_br_base
 #: model:res.city,name:l10n_br_base.city_3533601
 msgid "Nuporanga"
 msgstr ""
@@ -23204,7 +23195,6 @@ msgid "State Tax Numbers"
 msgstr ""
 
 #. module: l10n_br_base
-#: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_partner_form
 #: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_res_partner_address
 msgid "State..."
 msgstr ""
@@ -23215,7 +23205,6 @@ msgid "Street number..."
 msgstr ""
 
 #. module: l10n_br_base
-#: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_partner_form
 #: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_res_partner_address
 msgid "Street..."
 msgstr ""
@@ -27218,13 +27207,9 @@ msgid "Zacarias"
 msgstr ""
 
 #. module: l10n_br_base
+#: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_partner_contact_form
 #: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_res_partner_address
 msgid "Zip code..."
-msgstr ""
-
-#. module: l10n_br_base
-#: model_terms:ir.ui.view,arch_db:l10n_br_base.l10n_br_base_partner_form
-msgid "Zip..."
 msgstr ""
 
 #. module: l10n_br_base

--- a/l10n_br_base/views/res_partner_address_view.xml
+++ b/l10n_br_base/views/res_partner_address_view.xml
@@ -8,14 +8,14 @@
         <field name="arch" type="xml">
             <form>
                 <div class="o_address_format">
-                    <field name="zip" placeholder="Zip code..." class="o_address_zip"/>
+                    <field name="zip" placeholder="Zip code..."  style="width: 70%" class="o_address_zip"/>
                     <field name="street" placeholder="Street..." class="o_address_street"/>
                     <field name="street_number" placeholder="Street number..." class="o_address_street"/>
                     <field name="street2" placeholder="Complement..." class="o_address_street"/>
                     <field name="district" placeholder="District..." class="o_address_street"/>
-                    <field name="state_id" domain="[('country_id', '=', country_id)]" placeholder="State..." class="o_address_state" options='{"no_open": True, "no_create": True}'/>
-                    <field name="city_id" placeholder="City..." class="o_address_city" options='{"no_open": True, "no_create": True}' attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"/>
-                    <field name="city" placeholder="City..." class="o_address_city" force_save="True" attrs="{'invisible': [('country_id', '=', %(base.br)d)]}"/>
+                    <field name="state_id" domain="[('country_id', '=', country_id)]" placeholder="State..." style="width: 45%" class="o_address_state" options='{"no_open": True, "no_create": True}'/>
+                    <field name="city_id" placeholder="City..." style="width: 50%" class="o_address_city" options='{"no_open": True, "no_create": True}' attrs="{'invisible': [('country_id', '!=', %(base.br)d)]}"/>
+                    <field name="city" placeholder="City..." style="width: 50%" class="o_address_city" force_save="True" attrs="{'invisible': [('country_id', '=', %(base.br)d)]}"/>
                     <field name="country_id" placeholder="Country..." class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                 </div>
             </form>

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -86,26 +86,22 @@
                     </group>
                 </page>
             </page>
+        </field>
+    </record>
+
+    <record id="l10n_br_base_partner_contact_form" model="ir.ui.view">
+        <field name="name">l10n_br_base.res.partner.contact.form</field>
+        <field name="model">res.partner</field>
+        <field name="priority">9999</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
             <xpath expr="//div[@name='div_address']" position="replace">
-                <div name="div_address">
-                    <field name="zip" placeholder="Zip..." style="width: 20%"/>
-                    <div class="address_format">
-                        <field name="street" placeholder="Street..." style="width: 70%"/>
-                        <field name="street_number" placeholder="Number..." style="width: 20%"/>
-                    </div>
-                    <div class="address_format">
-                        <field name="street2" placeholder="Complement..." style="width: 45%"/>
-                        <field name="district" placeholder="District..." style="width: 45%"/>
-                    </div>
-                    <div class="address_format">
-                        <field name="country_id" placeholder="Country" class="oe_no_button"
-                               options="{&quot;no_open&quot;: True, &quot;no_create&quot;: True}"
-                               style="width: 30%"/>
-                        <field name="state_id" class="oe_no_button" placeholder="State..."
-                               style="width: 30%" options="{&quot;no_open&quot;: True}"
-                               domain="[('country_id','=',country_id)]"/>
-                        <field name="city_id" placeholder="City..." style="width: 30%"/>
-                    </div>
+                <div class="o_address_format">
+                    <field name="zip" placeholder="Zip code..."  style="width: 70%" class="o_address_zip"/>
+                    <!-- Some dummy field because i will be automatically replaced
+                    by odoo.src.odoo.addons.base.models.res_partner.FormatAddressMixin._fields_view_get_address
+                    loading l10n_br_base.l10n_br_base_res_partner_address and all of it's inheritances.
+                    -->
                 </div>
             </xpath>
         </field>

--- a/l10n_br_base/views/res_partner_view.xml
+++ b/l10n_br_base/views/res_partner_view.xml
@@ -38,6 +38,8 @@
             <field name="vat" position="replace"/>
             <xpath expr="//h1" position="after">
                 <group>
+                    <field name="city_id" invisible="1"/>
+                    <!-- Allow inject city_id on context above -->
                     <div class="oe_edit_only">
                         <label for="legal_name" string="Full Name"
                                attrs="{'invisible': [('is_company','=', True)]}"/>
@@ -86,6 +88,10 @@
                     </group>
                 </page>
             </page>
+            <xpath expr="//field[@name='child_ids']" position="attributes">
+                <!-- tracking_disable allow user to zip search on child_ids without save the child -->
+                <attribute name="context">{'tracking_disable': True, 'default_city_id': city_id}</attribute>
+            </xpath>
         </field>
     </record>
 

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima"],
     "website": "http://github.com/OCA/l10n-brazil",
-    "version": "12.0.11.1.1",
+    "version": "12.0.11.2.0",
     "depends": [
         "uom",
         "decimal_precision",

--- a/l10n_br_fiscal/__manifest__.py
+++ b/l10n_br_fiscal/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Akretion, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima"],
     "website": "http://github.com/OCA/l10n-brazil",
-    "version": "12.0.11.1.0",
+    "version": "12.0.11.1.1",
     "depends": [
         "uom",
         "decimal_precision",

--- a/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
+++ b/l10n_br_fiscal/i18n/l10n_br_fiscal.pot
@@ -3163,6 +3163,24 @@ msgid "FARDO"
 msgstr ""
 
 #. module: l10n_br_fiscal
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icmsfcp_value_wh
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icmsfcp_value_wh
+msgid "FCP WH"
+msgstr ""
+
+#. module: l10n_br_fiscal
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icmsfcp_percent_wh
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icmsfcp_percent_wh
+msgid "FCP WH %"
+msgstr ""
+
+#. module: l10n_br_fiscal
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icmsfcp_base_wh
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icmsfcp_base_wh
+msgid "FCP WH Base"
+msgstr ""
+
+#. module: l10n_br_fiscal
 #: model:uom.uom,name:l10n_br_fiscal.UOM_FOLHA
 msgid "FOLHA"
 msgstr ""
@@ -3875,6 +3893,35 @@ msgid "ICMS Destination Base"
 msgstr ""
 
 #. module: l10n_br_fiscal
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icms_effective_value
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icms_effective_value
+msgid "ICMS Effective"
+msgstr ""
+
+#. module: l10n_br_fiscal
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icms_effective_percent
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icms_effective_percent
+msgid "ICMS Effective %"
+msgstr ""
+
+#. module: l10n_br_fiscal
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icms_effective_reduction
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icms_effective_reduction
+msgid "ICMS Effective % Reduction"
+msgstr ""
+
+#. module: l10n_br_fiscal
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icms_effective_base
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icms_effective_base
+msgid "ICMS Effective Base"
+msgstr ""
+
+#. module: l10n_br_fiscal
+#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal.document_fiscal_line_mixin_form
+msgid "ICMS Effective Calculation"
+msgstr ""
+
+#. module: l10n_br_fiscal
 #: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icms_destination_percent
 #: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icms_destination_percent
 msgid "ICMS External %"
@@ -4579,6 +4626,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icms_sharing_percent
 #: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icms_sharing_percent
 msgid "ICMS Sharing %"
+msgstr ""
+
+#. module: l10n_br_fiscal
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icms_substitute
+#: model:ir.model.fields,field_description:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icms_substitute
+msgid "ICMS Substitute"
 msgstr ""
 
 #. module: l10n_br_fiscal
@@ -8903,6 +8956,12 @@ msgstr ""
 #: selection:l10n_br_fiscal.document.line.mixin,icms_base_type:0
 #: selection:l10n_br_fiscal.tax,icms_base_type:0
 msgid "Valor da Operação"
+msgstr ""
+
+#. module: l10n_br_fiscal
+#: model:ir.model.fields,help:l10n_br_fiscal.field_l10n_br_fiscal_document_line__icms_substitute
+#: model:ir.model.fields,help:l10n_br_fiscal.field_l10n_br_fiscal_document_line_mixin__icms_substitute
+msgid "Valor do ICMS Próprio do Substituto cobrado em operação anterior"
 msgstr ""
 
 #. module: l10n_br_fiscal

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -350,8 +350,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     icms_value = fields.Monetary(string="ICMS Value")
 
     # vICMSSubstituto - Valor do ICMS cobrado em operação anterior
-    icms_substitute = fields.Monetary(string="Substitute ICMS",
-                                      help="Valor do ICMS Próprio do Substituto cobrado em operação anterior")
+    icms_substitute = fields.Monetary(
+        string="Substitute ICMS",
+        help="Valor do ICMS Próprio do Substituto cobrado em operação anterior",
+    )
 
     # motDesICMS - Motivo da desoneração do ICMS
     icms_relief_id = fields.Many2one(

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -345,6 +345,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     icms_value = fields.Monetary(string="ICMS Value")
 
+    # vICMSSubstituto - Valor do ICMS cobrado em operação anterior
+    icms_substitute = fields.Monetary(string="Substitute ICMS",
+                                      help="Valor do ICMS Próprio do Substituto cobrado em operação anterior")
+
     # motDesICMS - Motivo da desoneração do ICMS
     icms_relief_id = fields.Many2one(
         comodel_name="l10n_br_fiscal.icms.relief",
@@ -440,6 +444,35 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     icmssn_percent = fields.Float(string="ICMS SN %")
 
     icmssn_credit_value = fields.Monetary(string="ICMS SN Credit")
+
+    # ICMS COBRADO ANTERIORMENTE POR ST
+    # vBCFCPSTRet
+    icmsfcp_base_wh = fields.Monetary(string="FCP WH Base",
+                                      help="Valor da base de cálculo do FCP retido anteriormente")
+
+    # pFCPSTRet
+    icmsfcp_percent_wh = fields.Float(string="FCP WH %",
+                                      help="Percentual do FCP retido anteriormente por ST")
+
+    # vFCPSTRet
+    icmsfcp_value_wh = fields.Monetary(string="FCP WH Value",
+                                       help="Valor do FCP retido anteriormente por ST")
+
+    # pRedBCEfet
+    effective_base_percent = fields.Float(string="Effective Base %",
+                                          help="Percentual de redução da base de cálculo efetiva")
+
+    # vBCEfet
+    effective_base_value = fields.Monetary(string="Effective Base Value",
+                                           help="Valor da base de cálculo efetiva")
+
+    # pICMSEfet
+    icms_effective_percent = fields.Float(string="ICMS Effective %",
+                                          help="Alíquota do ICMS efetiva")
+
+    # vICMSEfet
+    icms_effective_value = fields.Monetary(string="ICMS Effective Value",
+                                           help="Valor do ICMS Efetivo")
 
     # IPI Fields
     ipi_tax_id = fields.Many2one(

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -337,12 +337,16 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         string="ICMS Origin",
         default=ICMS_ORIGIN_DEFAULT)
 
+    # vBC - Valor da base de cálculo do ICMS
     icms_base = fields.Monetary(string="ICMS Base")
 
+    # pICMS - Alíquota do IMCS
     icms_percent = fields.Float(string="ICMS %")
 
+    # pRedBC - Percentual de redução do ICMS
     icms_reduction = fields.Float(string="ICMS % Reduction")
 
+    # vICMS - Valor do ICMS
     icms_value = fields.Monetary(string="ICMS Value")
 
     # vICMSSubstituto - Valor do ICMS cobrado em operação anterior
@@ -384,8 +388,10 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     # vICMSST - Valor do ICMS ST
     icmsst_value = fields.Monetary(string="ICMS ST Value")
 
+    # vBCSTRet - Valor da base de cálculo do ICMS ST retido
     icmsst_wh_base = fields.Monetary(string="ICMS ST WH Base")
 
+    # vICMSSTRet - Valor do IMCS ST Retido
     icmsst_wh_value = fields.Monetary(string="ICMS ST WH Value")
 
     # ICMS FCP Fields
@@ -441,38 +447,33 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     icmssn_reduction = fields.Monetary(string="ICMS SN Reduction")
 
+    # pCredICMSSN - Alíquota aplicável de cálculo do crédito (Simples Nacional)
     icmssn_percent = fields.Float(string="ICMS SN %")
 
+    # vCredICMSSN - Valor do crédito do ICMS que pode ser aproveitado
     icmssn_credit_value = fields.Monetary(string="ICMS SN Credit")
 
     # ICMS COBRADO ANTERIORMENTE POR ST
-    # vBCFCPSTRet
-    icmsfcp_base_wh = fields.Monetary(string="FCP WH Base",
-                                      help="Valor da base de cálculo do FCP retido anteriormente")
+    # vBCFCPSTRet - Valor da base de cálculo do FCP retido anteriormente
+    icmsfcp_base_wh = fields.Monetary(string="FCP WH Base")
 
-    # pFCPSTRet
-    icmsfcp_percent_wh = fields.Float(string="FCP WH %",
-                                      help="Percentual do FCP retido anteriormente por ST")
+    # pFCPSTRet - Percentual do FCP retido anteriormente por ST
+    icmsfcp_percent_wh = fields.Float(string="FCP WH %")
 
-    # vFCPSTRet
-    icmsfcp_value_wh = fields.Monetary(string="FCP WH Value",
-                                       help="Valor do FCP retido anteriormente por ST")
+    # vFCPSTRet - Valor do FCP retido anteriormente por ST
+    icmsfcp_value_wh = fields.Monetary(string="FCP WH Value")
 
-    # pRedBCEfet
-    effective_base_percent = fields.Float(string="Effective Base %",
-                                          help="Percentual de redução da base de cálculo efetiva")
+    # pRedBCEfet - Percentual de redução da base de cálculo efetiva
+    effective_base_percent = fields.Float(string="Effective Base %")
 
-    # vBCEfet
-    effective_base_value = fields.Monetary(string="Effective Base Value",
-                                           help="Valor da base de cálculo efetiva")
+    # vBCEfet - Valor da base de cálculo efetiva
+    effective_base_value = fields.Monetary(string="Effective Base Value")
 
-    # pICMSEfet
-    icms_effective_percent = fields.Float(string="ICMS Effective %",
-                                          help="Alíquota do ICMS efetiva")
+    # pICMSEfet - Alíquota do ICMS Efetiva
+    icms_effective_percent = fields.Float(string="ICMS Effective %")
 
-    # vICMSEfet
-    icms_effective_value = fields.Monetary(string="ICMS Effective Value",
-                                           help="Valor do ICMS Efetivo")
+    # vICMSEfet - Valor do ICMS Efetivo
+    icms_effective_value = fields.Monetary(string="ICMS Effective Value")
 
     # IPI Fields
     ipi_tax_id = fields.Many2one(

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -351,7 +351,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
 
     # vICMSSubstituto - Valor do ICMS cobrado em operação anterior
     icms_substitute = fields.Monetary(
-        string="Substitute ICMS",
+        string="ICMS Substitute",
         help="Valor do ICMS Próprio do Substituto cobrado em operação anterior",
     )
 
@@ -463,19 +463,19 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     icmsfcp_percent_wh = fields.Float(string="FCP WH %")
 
     # vFCPSTRet - Valor do FCP retido anteriormente por ST
-    icmsfcp_value_wh = fields.Monetary(string="FCP WH Value")
+    icmsfcp_value_wh = fields.Monetary(string="FCP WH")
 
     # pRedBCEfet - Percentual de redução da base de cálculo efetiva
-    effective_base_percent = fields.Float(string="Effective Base %")
+    icms_effective_reduction = fields.Float(string="ICMS Effective % Reduction")
 
     # vBCEfet - Valor da base de cálculo efetiva
-    effective_base_value = fields.Monetary(string="Effective Base Value")
+    icms_effective_base = fields.Monetary(string="ICMS Effective Base")
 
     # pICMSEfet - Alíquota do ICMS Efetiva
     icms_effective_percent = fields.Float(string="ICMS Effective %")
 
     # vICMSEfet - Valor do ICMS Efetivo
-    icms_effective_value = fields.Monetary(string="ICMS Effective Value")
+    icms_effective_value = fields.Monetary(string="ICMS Effective")
 
     # IPI Fields
     ipi_tax_id = fields.Many2one(

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -84,14 +84,14 @@
                         <field name="icms_base_type" force_save="1" attrs="{'readonly': ['|', ('icms_tax_id', '=', False), ('icmssn_tax_id', '=', False)]}"/>
                         <field name="icmssn_base" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icmssn_reduction" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
-                        <field name="icms_base" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', '!=', '900')]}"/>
-                        <field name="icms_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', '!=', '900')]}"/>
+                        <field name="icms_base" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '2'), ('icms_cst_code', 'not in', ('00', '10', '20', '30', '40', '41', '50', '51', '60', '70', '90', '900'))]}"/>
+                        <field name="icms_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '2'), ('icms_cst_code', 'not in', ('00', '10', '20', '30', '40', '41', '50', '51', '60', '70', '90', '900'))]}"/>
                       </group>
                       <group>
                         <field name="icmssn_percent" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icmssn_credit_value" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icms_reduction" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', '!=', '900')]}"/>
-                        <field name="icms_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', '!=', '900')]}"/>
+                        <field name="icms_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '2'), ('icms_cst_code', 'not in', ('00', '10', '20', '30', '40', '41', '50', '51', '60', '70', '90', '900'))]}"/>
                         <field name="icms_relief_id" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))]}"/>
                         <field name="icms_relief_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '70', '90'))]}"/>
                           <field name="icms_substitute" force_save="1" attrs="{'invisible': [('icms_cst_code', '!=', '500')]}"/>

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -84,20 +84,20 @@
                         <field name="icms_base_type" force_save="1" attrs="{'readonly': ['|', ('icms_tax_id', '=', False), ('icmssn_tax_id', '=', False)]}"/>
                         <field name="icmssn_base" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icmssn_reduction" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
-                        <field name="icms_base" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2'))]}"/>
-                        <field name="icms_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2'))]}"/>
+                        <field name="icms_base" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'not in', ('1', '3'))]}"/>
+                        <field name="icms_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'not in', ('1', '3'))]}"/>
                       </group>
                       <group>
                         <field name="icmssn_percent" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icmssn_credit_value" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icms_reduction" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2'))]}"/>
-                        <field name="icms_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2'))]}"/>
+                        <field name="icms_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'not in', ('1', '3'))]}"/>
                         <field name="icms_relief_id" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))]}"/>
                         <field name="icms_relief_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '70', '90'))]}"/>
                       </group>
                   </group>
                   <group>
-                      <group name="icmsst" string="ICMS ST" attrs="{'invisible': [('icms_cst_code', 'not in', ('10', '30', '70', '90', '201', '202', '203', '500'))]}">
+                      <group name="icmsst" string="ICMS ST" attrs="{'invisible': [('icms_cst_code', 'not in', ('10', '30', '70', '60', '90', '201', '202', '203', '500', '900'))]}">
                         <field name="icmsst_tax_id"/>
                         <field name="icmsst_base_type" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icmsst_mva_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)]}"/>

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -84,20 +84,21 @@
                         <field name="icms_base_type" force_save="1" attrs="{'readonly': ['|', ('icms_tax_id', '=', False), ('icmssn_tax_id', '=', False)]}"/>
                         <field name="icmssn_base" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icmssn_reduction" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
-                        <field name="icms_base" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'not in', ('1', '3'))]}"/>
-                        <field name="icms_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'not in', ('1', '3'))]}"/>
+                        <field name="icms_base" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', '!=', '900')]}"/>
+                        <field name="icms_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', '!=', '900')]}"/>
                       </group>
                       <group>
                         <field name="icmssn_percent" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icmssn_credit_value" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
-                        <field name="icms_reduction" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2'))]}"/>
-                        <field name="icms_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'not in', ('1', '3'))]}"/>
+                        <field name="icms_reduction" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', '!=', '900')]}"/>
+                        <field name="icms_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': ['|', ('tax_framework', '=', '3'), ('icms_cst_code', '!=', '900')]}"/>
                         <field name="icms_relief_id" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '40', '41', '50', '70', '90'))]}"/>
                         <field name="icms_relief_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('tax_framework', 'in', ('1', '2')), ('icms_cst_code', 'not in', ('20', '30', '70', '90'))]}"/>
+                          <field name="icms_substitute" force_save="1" attrs="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
                       </group>
                   </group>
                   <group>
-                      <group name="icmsst" string="ICMS ST" attrs="{'invisible': [('icms_cst_code', 'not in', ('10', '30', '70', '60', '90', '201', '202', '203', '500', '900'))]}">
+                      <group name="icmsst" string="ICMS ST" attrs="{'invisible': [('icms_cst_code', 'not in', ('10', '30', '70', '90', '201', '202', '203', '500', '900'))]}">
                         <field name="icmsst_tax_id"/>
                         <field name="icmsst_base_type" force_save="1" attrs="{'readonly': [('icmssn_tax_id', '!=', False)], 'invisible': [('tax_framework', '=', '3')]}"/>
                         <field name="icmsst_mva_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)]}"/>
@@ -108,7 +109,7 @@
                         <field name="icmsst_wh_base" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"/>
                         <field name="icmsst_wh_value" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)], 'invisible': [('icms_cst_code', 'not in', ('60', '500'))]}"/>
                       </group>
-                      <group name="icms_difal" string="ICMS DIFAL" attrs="{'invisible': [('partner_company_type', 'in', ('company', False)), ('tax_framework', '=', '3'), ('cfop_destination', 'in', ('1', '3', False))]}">
+                      <group name="icms_difal" string="ICMS DIFAL" attrs="{'invisible': [('partner_company_type', 'in', ('company', False)), ('tax_framework', '=', '3'), ('cfop_destination', 'in', ('1', '3', False)), ('icms_cst_code', 'in', ('101', '102', '103', '300', '400'))]}">
                         <field name="icms_destination_base" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)]}"/>
                         <field name="icms_origin_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)]}"/>
                         <field name="icms_destination_percent" force_save="1" attrs="{'readonly': [('icms_tax_id', '!=', False)]}"/>
@@ -119,6 +120,15 @@
                         <field name="icmsfcp_base" force_save="1" attrs="{'readonly': [('icmsfcp_tax_id', '!=', False)]}"/>
                         <field name="icmsfcp_percent" force_save="1" attrs="{'readonly': [('icmsfcp_tax_id', '!=', False)]}"/>
                         <field name="icmsfcp_value" force_save="1" attrs="{'readonly': [('icmsfcp_tax_id', '!=', False)]}"/>
+                          <field name="icmsfcp_base_wh" force_save="1" attrs="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
+                          <field name="icmsfcp_percent_wh" force_save="1" attrs="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
+                          <field name="icmsfcp_value_wh" force_save="1" attrs="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
+                      </group>
+                      <group name="icms_effective" string="ICMS Effective Calculation" attrs="{'invisible': [('icms_cst_code', '!=', '500')]}">
+                          <field name="effective_base_percent" force_save="1" attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
+                          <field name="effective_base_value" force_save="1" attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
+                          <field name="icms_effective_percent" force_save="1" attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
+                          <field name="icms_effective_value" force_save="1" attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
                       </group>
                   </group>
               </page>

--- a/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
+++ b/l10n_br_fiscal/views/document_fiscal_line_mixin_view.xml
@@ -125,8 +125,10 @@
                           <field name="icmsfcp_value_wh" force_save="1" attrs="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
                       </group>
                       <group name="icms_effective" string="ICMS Effective Calculation" attrs="{'invisible': [('icms_cst_code', '!=', '500')]}">
-                          <field name="effective_base_percent" force_save="1" attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
-                          <field name="effective_base_value" force_save="1" attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
+                          <field name="icms_effective_reduction" force_save="1"
+                                 attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
+                          <field name="icms_effective_base" force_save="1"
+                                 attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
                           <field name="icms_effective_percent" force_save="1" attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
                           <field name="icms_effective_value" force_save="1" attr="{'invisible': [('icms_cst_code', '!=', '500')]}"/>
                       </group>

--- a/l10n_br_fiscal/views/res_partner_view.xml
+++ b/l10n_br_fiscal/views/res_partner_view.xml
@@ -14,15 +14,6 @@
                     <field name="cnae_main_id"/>
                 </group>
             </group>
-            <field name="state_tax_number_ids" position="attributes">
-                <attribute name="attrs">{'invisible': [('ind_ie_dest','=', '9')]}</attribute>
-            </field>
-            <field name="inscr_est" position="attributes">
-                <attribute name="attrs">{'invisible': [('ind_ie_dest','=', '9')]}</attribute>
-            </field>
-            <div name="inscr_est" position="attributes">
-                <attribute name="attrs">{'invisible': [('ind_ie_dest','=', '9')]}</attribute>
-            </div>
         </field>
     </record>
 

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -11,7 +11,7 @@
               'Odoo Community Association (OCA)',
     "website": "http://github.com/OCA/l10n-brazil",
     "development_status": "Beta",
-    "version": "12.0.1.2.0",
+    "version": "12.0.1.3.0",
     "depends": [
         "l10n_br_fiscal",
         "l10n_br_nfe_spec",

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -11,7 +11,7 @@
               'Odoo Community Association (OCA)',
     "website": "http://github.com/OCA/l10n-brazil",
     "development_status": "Beta",
-    "version": "12.0.1.3.0",
+    "version": "12.0.1.3.1",
     "depends": [
         "l10n_br_fiscal",
         "l10n_br_nfe_spec",

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "BC do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,13 +1274,9 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
 msgid "Valor do COFINS"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1317,9 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
 msgid "Valor do PIS"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -1275,12 +1275,8 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
-msgid "Valor do COFINS ST"
+msgid "Valor do COFINS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1322,12 +1318,8 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS ST"
+msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "BC do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -242,7 +242,7 @@ msgid "CPF (v2.0)"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: code:addons/l10n_br_nfe/models/document.py:312
+#: code:addons/l10n_br_nfe/models/document.py:316
 #: code:addons/l10n_br_nfe/models/document_invalidate_number.py:22
 #, python-format
 msgid "Certificado não encontrado"
@@ -450,6 +450,11 @@ msgstr ""
 #. module: l10n_br_nfe
 #: model:ir.module.category,description:l10n_br_nfe.module_category_l10n_br_nfe
 msgid "Extends Odoo to helps you manage your brazilian fiscal documents: NF-e"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vBC
+msgid "FIXME Não usar esse campo!"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1275,12 +1280,7 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
-msgid "Valor do COFINS"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS sobre serviços"
+msgid "Valor do COFINS (NFe)"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1321,9 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS (NFe)"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1483,6 +1479,11 @@ msgstr ""
 #. module: l10n_br_nfe
 #: selection:l10n_br_fiscal.document.line,nfe40_choice20:0
 msgid "vUnid"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
+msgid "valor do COFINS (NFe)"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "BC do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,13 +1274,13 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 msgid "Valor do COFINS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
+msgid "Valor do COFINS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1321,9 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS ST"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "BC do ICMS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,9 +1274,13 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
-msgid "Valor do COFINS"
+msgid "Valor do COFINS ST"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
+msgid "Valor do COFINS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1317,9 +1321,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
 msgid "Valor do PIS"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
+msgid "Valor do PIS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -135,6 +135,11 @@ msgid "Add a new NFe"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,help:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vProd
+msgid "Amount without discount."
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model_terms:ir.ui.view,arch_db:l10n_br_nfe.nfe_document_form
 msgid "Amounts"
 msgstr ""

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "BC do ICMS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,9 +1274,13 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
 msgid "Valor do COFINS"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
+msgid "Valor do COFINS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1317,13 +1321,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
 msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS ST"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
+msgid "Valor do PIS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "BC do ICMS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,13 +1274,13 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
 msgid "Valor do COFINS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
-msgid "Valor do COFINS ST"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
+msgid "Valor do COFINS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1321,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
 msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS ST"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
+msgid "Valor do PIS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -1275,12 +1275,8 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
-msgid "Valor do COFINS ST"
+msgid "Valor do COFINS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1322,8 +1318,12 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
 msgid "Valor do PIS"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -1275,8 +1275,12 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
 msgid "Valor do COFINS"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
+msgid "Valor do COFINS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1318,8 +1322,12 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
 msgid "Valor do PIS"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "BC do ICMS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,9 +1274,13 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
 msgid "Valor do COFINS"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
+msgid "Valor do COFINS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1317,13 +1321,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS ST"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
+msgid "Valor do PIS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "BC do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,13 +1274,13 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 msgid "Valor do COFINS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
+msgid "Valor do COFINS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1321,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
 msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "BC do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,13 +1274,9 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
 msgid "Valor do COFINS"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1317,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS ST"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
+msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -157,6 +157,11 @@ msgid "BC do ICMS"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBCST
+msgid "BC do ICMS ST"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
@@ -242,7 +247,7 @@ msgid "CPF (v2.0)"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: code:addons/l10n_br_nfe/models/document.py:316
+#: code:addons/l10n_br_nfe/models/document.py:322
 #: code:addons/l10n_br_nfe/models/document_invalidate_number.py:22
 #, python-format
 msgid "Certificado não encontrado"
@@ -1261,6 +1266,11 @@ msgstr ""
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vICMS
 msgid "Valor Total do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vST
+msgid "Valor Total do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -1275,7 +1275,7 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
-msgid "Valor do COFINS"
+msgid "Valor do COFINS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "BC do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,13 +1274,9 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
-msgid "Valor do COFINS ST"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
+msgid "Valor do COFINS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1317,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS ST"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
+msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "BC do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,13 +1274,9 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
 msgid "Valor do COFINS"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1317,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
 msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "BC do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,13 +1274,9 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
 msgid "Valor do COFINS"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1317,9 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS ST"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -1318,12 +1318,8 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS ST"
+msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -1318,8 +1318,12 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
 msgid "Valor do PIS"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -1322,7 +1322,7 @@ msgstr ""
 
 #. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS"
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "BC do ICMS"
+msgstr ""
+
+#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
-msgstr ""
-
-#. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,13 +1274,9 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
-msgid "Valor do COFINS ST"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
-msgid "Valor do COFINS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
+msgid "Valor do COFINS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1321,13 +1317,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
 msgid "Valor do PIS"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
-msgid "Valor do PIS sobre serviços"
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
+msgid "Valor do PIS ST"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/i18n/l10n_br_nfe.pot
+++ b/l10n_br_nfe/i18n/l10n_br_nfe.pot
@@ -152,15 +152,15 @@ msgid "BC Code"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
-msgid "BC do ICMS"
-msgstr ""
-
-#. module: l10n_br_nfe
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_hr_employee_dependent__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_partner__nfe40_xBairro
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_res_users__nfe40_xBairro
 msgid "Bairro"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vBC
+msgid "Base de Cálculo do ISS"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1274,9 +1274,13 @@ msgid "Valor da BC do ICMS ST"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vCOFINS
-msgid "Valor do COFINS"
+msgid "Valor do COFINS ST"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vCOFINS
+msgid "Valor do COFINS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe
@@ -1317,9 +1321,13 @@ msgid "Valor do IPI"
 msgstr ""
 
 #. module: l10n_br_nfe
-#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
 #: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document_line__nfe40_vPIS
-msgid "Valor do PIS"
+msgid "Valor do PIS ST"
+msgstr ""
+
+#. module: l10n_br_nfe
+#: model:ir.model.fields,field_description:l10n_br_nfe.field_l10n_br_fiscal_document__nfe40_vPIS
+msgid "Valor do PIS sobre serviços"
 msgstr ""
 
 #. module: l10n_br_nfe

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -217,8 +217,10 @@ class NFe(spec_models.StackedModel):
     nfe40_vTotTrib = fields.Monetary(
         related='amount_estimate_tax'
     )
+
     nfe40_vBC = fields.Monetary(
-        related='amount_icms_base'
+        string='BC do ICMS',
+        related='amount_icms_base',
     )
 
     nfe40_vICMS = fields.Monetary(
@@ -226,6 +228,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_vPIS = fields.Monetary(
+        string='Valor do PIS (NFe)',
         related='amount_pis_value'
     )
 
@@ -234,6 +237,7 @@ class NFe(spec_models.StackedModel):
     )
 
     nfe40_vCOFINS = fields.Monetary(
+        string='valor do COFINS (NFe)',
         related='amount_cofins_value'
     )
 

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -220,9 +220,15 @@ class NFe(spec_models.StackedModel):
     nfe40_vBC = fields.Monetary(
         related='amount_icms_base'
     )
+    nfe40_vBCST = fields.Monetary(
+        related='amount_icmsst_base'
+    )
 
     nfe40_vICMS = fields.Monetary(
         related='amount_icms_value'
+    )
+    nfe40_vST = fields.Monetary(
+        related='amount_icmsst_value'
     )
 
     nfe40_vPIS = fields.Monetary(

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -71,7 +71,7 @@ class NFeLine(spec_models.StackedModel):
     )
 
     nfe40_vProd = fields.Monetary(
-        related='amount_untaxed',
+        related='price_gross',
     )
 
     nfe40_choice9 = fields.Selection([

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -140,10 +140,12 @@ class NFeLine(spec_models.StackedModel):
     )
 
     nfe40_vPIS = fields.Monetary(
+        string='Valor do PIS (NFe)',
         related='pis_value',
     )
 
     nfe40_vCOFINS = fields.Monetary(
+        string='Valor do COFINS (NFe)',
         related='cofins_value',
     )
 
@@ -213,6 +215,10 @@ class NFeLine(spec_models.StackedModel):
     nfe40_vDesc = fields.Monetary(
         related='discount_value'
     )
+
+    # TODO toxic field from several tags, should not even be injected!
+    # meanwhile forcing a string on it avoids .pot issues.
+    nfe40_vBC = fields.Monetary(string='FIXME Não usar esse campo!')
 
     nfe40_vBCST = fields.Monetary(
         related='icmsst_base'

--- a/l10n_br_repair/i18n/l10n_br_repair.pot
+++ b/l10n_br_repair/i18n/l10n_br_repair.pot
@@ -456,6 +456,21 @@ msgid "Extra Info"
 msgstr ""
 
 #. module: l10n_br_repair
+#: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icmsfcp_value_wh
+msgid "FCP WH"
+msgstr ""
+
+#. module: l10n_br_repair
+#: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icmsfcp_percent_wh
+msgid "FCP WH %"
+msgstr ""
+
+#. module: l10n_br_repair
+#: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icmsfcp_base_wh
+msgid "FCP WH Base"
+msgstr ""
+
+#. module: l10n_br_repair
 #: model:ir.model.fields,field_description:l10n_br_repair.field_repair_order__fiscal_document_count
 msgid "Fiscal Document Count"
 msgstr ""
@@ -573,6 +588,26 @@ msgid "ICMS Destination Base"
 msgstr ""
 
 #. module: l10n_br_repair
+#: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icms_effective_value
+msgid "ICMS Effective"
+msgstr ""
+
+#. module: l10n_br_repair
+#: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icms_effective_percent
+msgid "ICMS Effective %"
+msgstr ""
+
+#. module: l10n_br_repair
+#: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icms_effective_reduction
+msgid "ICMS Effective % Reduction"
+msgstr ""
+
+#. module: l10n_br_repair
+#: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icms_effective_base
+msgid "ICMS Effective Base"
+msgstr ""
+
+#. module: l10n_br_repair
 #: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icms_destination_percent
 msgid "ICMS External %"
 msgstr ""
@@ -680,6 +715,11 @@ msgstr ""
 #. module: l10n_br_repair
 #: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icms_sharing_percent
 msgid "ICMS Sharing %"
+msgstr ""
+
+#. module: l10n_br_repair
+#: model:ir.model.fields,field_description:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icms_substitute
+msgid "ICMS Substitute"
 msgstr ""
 
 #. module: l10n_br_repair
@@ -1511,6 +1551,11 @@ msgstr ""
 #. module: l10n_br_repair
 #: selection:l10n_br_repair.fiscal.line.mixin,icms_base_type:0
 msgid "Valor da Operação"
+msgstr ""
+
+#. module: l10n_br_repair
+#: model:ir.model.fields,help:l10n_br_repair.field_l10n_br_repair_fiscal_line_mixin__icms_substitute
+msgid "Valor do ICMS Próprio do Substituto cobrado em operação anterior"
 msgstr ""
 
 #. module: l10n_br_repair

--- a/l10n_br_zip/tests/test_l10n_br_zip_res_company.py
+++ b/l10n_br_zip/tests/test_l10n_br_zip_res_company.py
@@ -2,8 +2,16 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from unittest import mock
 
 from odoo.tests.common import TransactionCase
+
+_module_ns = 'odoo.addons.l10n_br_zip'
+_provider_class = (
+    _module_ns
+    + '.models.l10n_br_zip'
+    + '.L10nBrZip'
+)
 
 
 class L10nBRZipTest(TransactionCase):
@@ -57,7 +65,20 @@ class L10nBRZipTest(TransactionCase):
         """Test search zip code."""
 
         self.company.zip = "01310923"
-        self.company.zip_search()
+
+        mocked_response = {
+            "zip_code": '01310923',
+            "street": "Avenida Avenida Paulista 1842",
+            "district": "Centro",
+            "city_id": self.env.ref('l10n_br_base.city_3550308').id,
+            "state_id": self.env.ref('base.state_br_sp').id,
+            "country_id": self.env.ref('base.br').id,
+        }
+        with mock.patch(
+                _provider_class + '._consultar_cep',
+                return_value=mocked_response,
+        ):
+            self.company.zip_search()
         self.assertEquals(
             self.company.district,
             "Bela Vista",
@@ -166,8 +187,23 @@ class L10nBRZipTest(TransactionCase):
     def test_return_pycep_correios(self):
         """Test search with PyCEP CORREIOS ."""
 
+        mocked_response = {
+            'zip_code': '04003000',
+            'street': 'Rua Coronel Oscar Porto',
+            'zip_complement': '- até 219/220',
+            'district': 'Paraíso',
+            "city_id": self.env.ref('l10n_br_base.city_3550308').id,
+            "state_id": self.env.ref('base.state_br_sp').id,
+            "country_id": self.env.ref('base.br').id,
+        }
+
         self.company.zip = "04003000"
-        self.company.zip_search()
+
+        with mock.patch(
+                _provider_class + '._consultar_cep',
+                return_value=mocked_response,
+        ):
+            self.company.zip_search()
         self.assertEquals(
             self.company.district,
             "Paraíso",

--- a/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
+++ b/l10n_br_zip/tests/test_l10n_br_zip_res_partner.py
@@ -2,8 +2,16 @@
 #   Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from unittest import mock
 
 from odoo.tests.common import TransactionCase
+
+_module_ns = 'odoo.addons.l10n_br_zip'
+_provider_class = (
+    _module_ns
+    + '.models.l10n_br_zip'
+    + '.L10nBrZip'
+)
 
 
 class L10nBRZipTest(TransactionCase):
@@ -169,9 +177,23 @@ class L10nBRZipTest(TransactionCase):
 
     def test_return_pycep_correios(self):
         """Test search with PyCEP CORREIOS in res_partner."""
+        mocked_response = {
+            'zip_code': '01310930',
+            'street': 'Avenida Paulista, 2100',
+            'zip_complement': None,
+            'district': 'Bela Vista',
+            "city_id": self.env.ref('l10n_br_base.city_3550308').id,
+            "state_id": self.env.ref('base.state_br_sp').id,
+            "country_id": self.env.ref('base.br').id,
+        }
 
         self.res_partner.zip = "01310930"
-        self.res_partner.zip_search()
+
+        with mock.patch(
+                _provider_class + '._consultar_cep',
+                return_value=mocked_response,
+        ):
+            self.res_partner.zip_search()
         self.assertEquals(
             self.res_partner.district,
             "Bela Vista",


### PR DESCRIPTION
1. https://github.com/OCA/l10n-brazil/pull/1270 Bug: Alguns campos do faltantes do simples nacional exportados na NF-e;
2. https://github.com/OCA/l10n-brazil/pull/1304 Bug: Força a tradução de alguns campos dinâmicos da estrutura da NF-e;
3. https://github.com/OCA/l10n-brazil/pull/1294 Melhoria: Formulário de contatos com busca de CEP e mesma visão do formulário de cadastro de parceiros;
![image](https://user-images.githubusercontent.com/1975978/116056412-2699a800-a654-11eb-8d36-be9cf6b7d262.png)
4. https://github.com/OCA/l10n-brazil/pull/1307 Bug: Exportação dos campos nfe40_vBCST nfe40_vST no XML;
5. https://github.com/OCA/l10n-brazil/pull/1309 Bug: Quando uma NF-e tem descontos o valor do vProd (total de mercadorias esta incorreto).
6. https://github.com/OCA/l10n-brazil/pull/1308 Bug: Exibição da IE, mesmo que o parceiro seja não é contribuinte.

