### PR TITLE
[FIX] street_number

### DIFF
--- a/l10n_br_receitaws/models/l10n_br_base_party_mixin.py
+++ b/l10n_br_receitaws/models/l10n_br_base_party_mixin.py
@@ -68,10 +68,10 @@ class PartyMixin(models.AbstractModel):
                 self.street2 = data['complemento'].title()
             if data.get('cep') != '':
                 self.zip = data['cep']
-            if data.get('numero') != '':
-                self.street_number = data['numero']
             if data.get('logradouro') != '':
                 self.street = data['logradouro'].title()
+            if data.get('numero') != '':
+                self.street_number = data['numero']
             if data.get('bairro') != '':
                 self.district = data['bairro'].title()
 


### PR DESCRIPTION
O campo street_number está sendo informado errado, isso só acontece quando o nome do logradouro é formado por um número exemplo: **ROD. BR 101.**

Na verdade o **street_number** é carregado corretamente do serviço da receitaws porém é sobreescrito logo que é informado o logradouro.

Pelo que vi existe um comportamento padrão no Odoo que pega o número informado dentro do campo street (logradouro) e joga automaticamente no street_number:

![Peek 2021-07-06 21-45](https://user-images.githubusercontent.com/634278/124684726-27e21f00-dea6-11eb-8961-f3e4feefc444.gif)

A forma de resolver isso foi trocar a ordem que é carregado essas informaçoes: primeiro o logradouro e depois o street_number.

