### PR TITLE
[FIX] l10n_br_fiscal: icmsfcp base

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -535,6 +535,12 @@ class Tax(models.Model):
             )
             tax_dict["fcpst_value"] -= tax_dict["tax_value"]
 
+        # As duas atribuições abaixo se tratam de uma solução paliativa
+        # para o problema de duplicação do frete na base do FCP.
+        # Esse problema só é observado na branch:
+        # https://github.com/kmee/l10n-brazil/tree/14.0-imp-tax-manual-values
+        taxes_dict["add_to_base"] = 0.00
+        taxes_dict["remove_from_base"] = 0.00
         return self._compute_tax(tax, taxes_dict, **kwargs)
 
     @api.model


### PR DESCRIPTION
O commit https://github.com/kmee/l10n-brazil/commit/d029b48ad9278e4711cb2ac4e81d7c5f8fae5015 introduziu um comportamento indesejado no método `_compute_icmsfcp`. Quando a linha da sale order tem frete, a base do FCP fica diferente do ICMS , o frete é adicionado na base do FCP duas vezes.

Esse PR evita esse comportamento com uma correção paliativa.

@mileo , @DiegoParadeda 