### PR TITLE
[14.0][FIX] l10n_br_fiscal: remove duplicated condition and fix ICMS regulation logic

### DIFF
--- a/l10n_br_fiscal/models/icms_regulation.py
+++ b/l10n_br_fiscal/models/icms_regulation.py
@@ -2106,7 +2106,7 @@ class ICMSRegulation(models.Model):
             company.state_id != partner.state_id
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and operation_line.fiscal_operation_type == FISCAL_OUT
-            or operation_line.fiscal_operation_id.fiscal_type == "return_in"
+            or operation_line.fiscal_operation_id.fiscal_type != "return_in"
             and operation_line.fiscal_operation_type == FISCAL_IN
         ):
             domain = self._build_map_tax_def_domain(

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -393,7 +393,7 @@ class Tax(models.Model):
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
             and operation_line.fiscal_operation_type == FISCAL_OUT
-            and operation_line.fiscal_operation_type == FISCAL_OUT
+            and operation_line.fiscal_operation_type == FISCAL_IN
             and operation_line.fiscal_operation_id.fiscal_type != "return_in"
         ):
             icms_tax_difal, _ = company.icms_regulation_id.map_tax_def_icms_difal(


### PR DESCRIPTION
Removida a duplicação da condição "and operation_line.fiscal_operation_type == FISCAL_OUT" e ajustada a lógica do  icms_regulation no método map_tax_def_icms_difal, garantindo que o valor seja retornado corretamente, sem sinal negativo e sem ser dobrado.

Relacionado a [PR](https://github.com/OCA/l10n-brazil/pull/3686)

cc @mileo @corredato