### PR TITLE
[14.0][RFC] l10n_br_fiscal: tax logic

### DIFF
--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -392,9 +392,13 @@ class Tax(models.Model):
             and cfop.destination == CFOP_DESTINATION_EXTERNAL
             and partner.ind_ie_dest == NFE_IND_IE_DEST_9
             and tax_dict.get("tax_value")
-            and operation_line.fiscal_operation_type == FISCAL_OUT
-            and operation_line.fiscal_operation_type == FISCAL_IN
-            and operation_line.fiscal_operation_id.fiscal_type != "return_in"
+            and (
+                operation_line.fiscal_operation_type == FISCAL_OUT
+                or (
+                    operation_line.fiscal_operation_type == FISCAL_IN
+                    and operation_line.fiscal_operation_id.fiscal_type != "return_in"
+                )
+            )
         ):
             icms_tax_difal, _ = company.icms_regulation_id.map_tax_def_icms_difal(
                 company, partner, product, ncm, nbm, cest, operation_line, ind_final


### PR DESCRIPTION
cc @corredato

Durante a análise do código, foi identificada uma condição que contém uma contradição lógica e que pode comprometer o comportamento esperado da aplicação.

### ❌ Condição Incorreta

```python
if (
    cfop
    and cfop.destination == CFOP_DESTINATION_EXTERNAL
    and partner.ind_ie_dest == NFE_IND_IE_DEST_9
    and tax_dict.get("tax_value")
    and operation_line.fiscal_operation_type == FISCAL_OUT
    and operation_line.fiscal_operation_type == FISCAL_IN
    and operation_line.fiscal_operation_id.fiscal_type != "return_in"
):
```

A lógica acima exige que o campo operation_line.fiscal_operation_type seja, ao mesmo tempo, igual a FISCAL_OUT e a FISCAL_IN. Isso é impossível, pois o campo só pode conter um valor por vez. Como resultado, essa condição nunca será verdadeira, o que pode impedir a execução correta de regras fiscais importantes.

### ✅  Condição Correta

Para que a lógica funcione corretamente e atenda aos diferentes cenários de operação (saída ou entrada válida), é necessário usar o operador or:

```
if (
    cfop
    and cfop.destination == CFOP_DESTINATION_EXTERNAL
    and partner.ind_ie_dest == NFE_IND_IE_DEST_9
    and tax_dict.get("tax_value")
    and (
        operation_line.fiscal_operation_type == FISCAL_OUT
        or (
            operation_line.fiscal_operation_type == FISCAL_IN
            and operation_line.fiscal_operation_id.fiscal_type != "return_in"
        )
    )
):
```
Essa abordagem assegura que a verificação será feita corretamente para operações de saída ou, no caso de entrada, desde que não sejam devoluções (return_in).

Relacionado a [PR 3686](https://github.com/OCA/l10n-brazil/pull/3686)