### PR TITLE
[FIX] l10n_br_nfse_paulistana: adapt tests to Odoo 18

### DIFF
--- a/l10n_br_nfse_paulistana/tests/nfse/paulistana.xml
+++ b/l10n_br_nfse_paulistana/tests/nfse/paulistana.xml
@@ -51,7 +51,7 @@
         </EnderecoTomador>
         <EmailTomador>cliente1@cliente1.com.br</EmailTomador>
         <Discriminacao
-        >[ODOO_DEV] Customized Odoo Development|Documento emitido por: Marc Demo|</Discriminacao>
+        >Customized Odoo Development|Documento emitido por: Marc Demo|</Discriminacao>
         <ValorCargaTributaria>0</ValorCargaTributaria>
         <FonteCargaTributaria>IBPT</FonteCargaTributaria>
     </RPS>

--- a/l10n_br_nfse_paulistana/tests/test_fiscal_document_nfse_paulistana.py
+++ b/l10n_br_nfse_paulistana/tests/test_fiscal_document_nfse_paulistana.py
@@ -23,6 +23,7 @@ class TestFiscalDocumentNFSePaulistana(TestFiscalDocumentNFSeCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env["res.lang"]._activate_lang("pt_BR")
         cls.company.provedor_nfse = "paulistana"
 
     def test_nfse_paulistana(self):
@@ -32,18 +33,10 @@ class TestFiscalDocumentNFSePaulistana(TestFiscalDocumentNFSeCommon):
             l10n_br_nfse_paulistana.__path__[0], "tests", "nfse", "paulistana.xml"
         )
 
-        self.nfse_same_state._onchange_document_serie_id()
-        self.nfse_same_state._onchange_fiscal_operation_id()
-        self.nfse_same_state._onchange_company_id()
         self.nfse_same_state.rps_number = "50"
         self.nfse_same_state.document_number = "50"
 
         for line in self.nfse_same_state.fiscal_line_ids:
-            line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
-            line._onchange_fiscal_operation_id()
-            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
         self.nfse_same_state.action_document_confirm()
@@ -72,18 +65,10 @@ class TestFiscalDocumentNFSePaulistana(TestFiscalDocumentNFSeCommon):
 
     def test_serialize_nfse_paulistana(self):
         """Test serialization of NFS-e Paulistana."""
-        self.nfse_same_state._onchange_document_serie_id()
-        self.nfse_same_state._onchange_fiscal_operation_id()
-        self.nfse_same_state._onchange_company_id()
         self.nfse_same_state.rps_number = "50"
         self.nfse_same_state.document_number = "50"
 
         for line in self.nfse_same_state.fiscal_line_ids:
-            line._onchange_product_id_fiscal()
-            line._onchange_commercial_quantity()
-            line._onchange_ncm_id()
-            line._onchange_fiscal_operation_id()
-            line._onchange_fiscal_operation_line_id()
             line._onchange_fiscal_taxes()
 
         self.nfse_same_state.action_document_confirm()
@@ -97,9 +82,6 @@ class TestFiscalDocumentNFSePaulistana(TestFiscalDocumentNFSeCommon):
 
     def test_map_taxation_rps(self):
         """Test mapping of taxation RPS."""
-        self.nfse_same_state._onchange_document_serie_id()
-        self.nfse_same_state._onchange_fiscal_operation_id()
-
         # Test all taxation mappings
         self.assertEqual(self.nfse_same_state._map_taxation_rps("1"), "T")
         self.assertEqual(self.nfse_same_state._map_taxation_rps("2"), "F")
@@ -110,8 +92,6 @@ class TestFiscalDocumentNFSePaulistana(TestFiscalDocumentNFSeCommon):
 
     def test_map_type_rps(self):
         """Test mapping of RPS type."""
-        self.nfse_same_state._onchange_document_serie_id()
-
         # Test all RPS type mappings
         self.assertEqual(self.nfse_same_state._map_type_rps("1"), "RPS")
         self.assertEqual(self.nfse_same_state._map_type_rps("2"), "RPS-M")
@@ -119,8 +99,6 @@ class TestFiscalDocumentNFSePaulistana(TestFiscalDocumentNFSeCommon):
 
     def test_map_provision_municipality(self):
         """Test mapping of provision municipality."""
-        self.nfse_same_state._onchange_document_serie_id()
-
         # Test provision municipality mapping
         self.assertIsNone(self.nfse_same_state._map_provision_municipality("1", "3550308"))
         self.assertEqual(


### PR DESCRIPTION
## Contexto

Os testes do `l10n_br_nfse_paulistana` na branch `18.0-paulistana` ainda usavam APIs do 16.0 e falhavam ao rodar num ambiente 18.0 limpo (5 errors de 5 tests).

## Correções

1. **Onchanges extintos**: removidas as chamadas a `_onchange_document_serie_id`, `_onchange_fiscal_operation_id`, `_onchange_company_id`, `_onchange_product_id_fiscal`, `_onchange_commercial_quantity`, `_onchange_ncm_id` e `_onchange_fiscal_operation_line_id` — esses métodos não existem mais no `l10n_br_fiscal` 18.0 (`AttributeError`). Mantida apenas `_onchange_fiscal_taxes`, que ainda existe em `document_line_mixin`.
2. **Idioma pt_BR**: `test_nfse_paulistana` exporta com `with_context(lang="pt_BR")` e quebrava com `UserError: Invalid language code: pt_BR` em DB sem o idioma. Ativado via `res.lang._activate_lang("pt_BR")` no `setUpClass`.
3. **Fixture atualizado**: sem o onchange de produto, o nome da linha demo não é mais reescrito para `[ODOO_DEV] Customized Odoo Development` — o XML esperado foi ajustado para o comportamento do 18.0 (`Discriminacao` sem o prefixo do default_code).

## Resultado

`invoke test -m l10n_br_nfse_paulistana` num doodba 18.0: **0 failed, 0 errors** (antes: 5 errors). O `test_nfse_paulistana` volta a validar o XML `PedidoEnvioLoteRPS` gerado por diff contra o fixture de referência.
