### PR TITLE
[IMP] l10n_br_nfse_paulistana: serializador parametrizado para schema v02 (Reforma Tributária)

### DIFF
--- a/l10n_br_nfse_paulistana/models/document.py
+++ b/l10n_br_nfse_paulistana/models/document.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 
 from erpbrasil.base import misc
+from nfselib.paulistana.v02 import PedidoEnvioLoteRPS as lote_rps_v02
 from nfselib.paulistana.v02.PedidoEnvioLoteRPS import (
     CabecalhoType,
     PedidoEnvioLoteRPS,
@@ -13,7 +14,16 @@ from nfselib.paulistana.v02.PedidoEnvioLoteRPS import (
     tpEndereco,
     tpRPS,
 )
+from nfselib.paulistana.v03 import PedidoEnvioLoteRPS as lote_rps_v03
 from unidecode import unidecode
+
+# Schema v01 (legado, fato gerador até 31/12/2025) = bindings v02, Versao=1.
+# Schema v02 (Reforma Tributária IBS/CBS) = bindings v03, Versao=2; nele
+# tpAssinatura exporta em base64 (bytes) e ISSRetido é xs:boolean.
+PAULISTANA_BINDINGS = {
+    "v02": {"module": lote_rps_v02, "versao": 1},
+    "v03": {"module": lote_rps_v03, "versao": 2},
+}
 
 from odoo import _, models
 from odoo.exceptions import UserError
@@ -72,18 +82,24 @@ class Document(models.Model):
             edocs.append(record.serialize_nfse_paulistana())
         return edocs
 
-    def serialize_nfse_paulistana(self):
+    def serialize_nfse_paulistana(self, nfse_version="v02"):
+        binding = PAULISTANA_BINDINGS[nfse_version]
         dados_lote_rps = self._prepare_lote_rps()
         dados_servico = self._prepare_dados_servico()
-        lote_rps = PedidoEnvioLoteRPS(
-            Cabecalho=self._serialize_cabecalho(dados_lote_rps),
-            RPS=[self._serialize_lote_rps(dados_lote_rps, dados_servico)],
+        lote_rps = binding["module"].PedidoEnvioLoteRPS(
+            Cabecalho=self._serialize_cabecalho(dados_lote_rps, binding),
+            RPS=[self._serialize_lote_rps(dados_lote_rps, dados_servico, binding)],
         )
         return lote_rps
 
-    def _serialize_cabecalho(self, dados_lote_rps):
+    def _serialize_cabecalho(self, dados_lote_rps, binding=None):
+        binding = binding or PAULISTANA_BINDINGS["v02"]
+        CabecalhoType = binding["module"].CabecalhoType
+        tpCPFCNPJ = binding["module"].tpCPFCNPJ
         return CabecalhoType(
-            Versao=self.convert_type_nfselib(CabecalhoType, "Versao", 1),
+            Versao=self.convert_type_nfselib(
+                CabecalhoType, "Versao", binding["versao"]
+            ),
             CPFCNPJRemetente=tpCPFCNPJ(
                 CNPJ=self.convert_type_nfselib(
                     CabecalhoType, "tpCPFCNPJ", dados_lote_rps["cnpj"]
@@ -107,12 +123,20 @@ class Document(models.Model):
             ),
         )
 
-    def _serialize_lote_rps(self, dados_lote_rps, dados_servico):
+    def _serialize_lote_rps(self, dados_lote_rps, dados_servico, binding=None):
+        binding = binding or PAULISTANA_BINDINGS["v02"]
+        tpRPS = binding["module"].tpRPS
+        tpChaveRPS = binding["module"].tpChaveRPS
+        tpCPFCNPJ = binding["module"].tpCPFCNPJ
+        tpEndereco = binding["module"].tpEndereco
         dados_tomador = self._prepare_dados_tomador()
+        assinatura = self.assinatura_rps(dados_lote_rps, dados_servico, dados_tomador)
+        if binding["versao"] >= 2:
+            # tpAssinatura no schema v02 é xs:base64Binary: o export do
+            # generateDS aplica b64encode e exige bytes.
+            assinatura = assinatura.encode("ascii")
         return tpRPS(
-            Assinatura=self.assinatura_rps(
-                dados_lote_rps, dados_servico, dados_tomador
-            ),
+            Assinatura=assinatura,
             ChaveRPS=tpChaveRPS(
                 InscricaoPrestador=self.convert_type_nfselib(
                     tpChaveRPS,

--- a/l10n_br_nfse_paulistana/tests/test_fiscal_document_nfse_paulistana.py
+++ b/l10n_br_nfse_paulistana/tests/test_fiscal_document_nfse_paulistana.py
@@ -80,6 +80,35 @@ class TestFiscalDocumentNFSePaulistana(TestFiscalDocumentNFSeCommon):
         self.assertTrue(hasattr(serialized, "RPS"))
         self.assertEqual(len(serialized.RPS), 1)
 
+    def test_serialize_nfse_paulistana_v03(self):
+        """Test serialization with v03 bindings (schema v02, Reforma Tributária)."""
+        import io
+
+        self.nfse_same_state.rps_number = "50"
+        self.nfse_same_state.document_number = "50"
+
+        for line in self.nfse_same_state.fiscal_line_ids:
+            line._onchange_fiscal_taxes()
+
+        self.nfse_same_state.action_document_confirm()
+
+        serialized = self.nfse_same_state.serialize_nfse_paulistana(
+            nfse_version="v03"
+        )
+        self.assertEqual(
+            type(serialized).__module__, "nfselib.paulistana.v03.PedidoEnvioLoteRPS"
+        )
+        self.assertEqual(serialized.Cabecalho.Versao, 2)
+        self.assertEqual(len(serialized.RPS), 1)
+        # tpAssinatura no schema v02 é xs:base64Binary: o campo deve ser bytes
+        self.assertIsInstance(serialized.RPS[0].Assinatura, bytes)
+
+        buf = io.StringIO()
+        serialized.export(buf, 0, pretty_print=True)
+        xml = buf.getvalue()
+        self.assertIn('Versao="2"', xml)
+        self.assertIn("<Discriminacao>", xml)
+
     def test_map_taxation_rps(self):
         """Test mapping of taxation RPS."""
         # Test all taxation mappings


### PR DESCRIPTION
## Contexto

Preparação para a emissão de NFS-e paulistana com os schemas da **Reforma Tributária 2026** (IBS/CBS). Empilhado sobre #732 (fix dos testes) — mergear aquele primeiro.

Na `nfselib.paulistana`, o pacote `v03` contém as bindings do schema v02 da prefeitura (zip `schemas-reformatributaria-v02-4`, Manual WS v3.3.7).

## O que muda

- Novo registro `PAULISTANA_BINDINGS` mapeando `nfse_version` → módulo de bindings + `Versao` do cabeçalho (`v02`→1, `v03`→2).
- `serialize_nfse_paulistana(nfse_version="v02")` — **default mantém o comportamento atual** (schema legado). Com `"v03"", gera o lote no schema novo.
- No schema v02, `tpAssinatura` virou `xs:base64Binary` (o export do generateDS aplica b64encode e exige bytes) → a string de 86 posições do RPS é codificada em ascii antes da atribuição. Mesmo ponto do bug latente no erpbrasil/erpbrasil.edoc#94, que perdeu o `.encode("ascii")`.
- Teste novo `test_serialize_nfse_paulistana_v03` validando módulo de binding, `Versao=2`, assinatura em bytes e export do XML.

## ⚠️ Gap conhecido (follow-up necessário antes de emissão real com v03)

No schema v02 os campos de valores mudaram de estrutura: `ValorTotalServicos`/`ValorTotalDeducoes` (Cabecalho) e `ValorServicos` (RPS) **não são mais aceitos com esses nomes** — o construtor do generateDS engole kwargs desconhecidos silenciosamente e o XML sai **sem os valores de serviço**. O mapeamento dos valores e dos grupos novos (IBS/CBS, `tpValores`, `RetencaoPisCofins`/NT-007) fica para PR subsequente.

## Testes

`invoke test -m l10n_br_nfse_paulistana` num doodba 18.0: **6 testes, 0 failed, 0 errors**.
