### PR TITLE
[16.0][IMP] l10n_br_coa: classificação de fluxo de caixa, valor adicionado e resultado abrangente

### DIFF
--- a/l10n_br_coa/__manifest__.py
+++ b/l10n_br_coa/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Base dos Planos de Contas",
     "summary": """
         Base do Planos de Contas brasileiros""",
-    "version": "16.0.2.8.0",
+    "version": "16.0.2.9.0",
     "license": "AGPL-3",
     "author": "Akretion, KMEE, Odoo Community Association (OCA)",
     "maintainers": ["renatonlima", "mileo"],
@@ -17,8 +17,13 @@
         # security
         "security/ir.model.access.csv",
         # Data
-        "data/l10n_br_coa_template.xml",
+        # As etiquetas vêm ANTES do plano de propósito: ao carregar o
+        # `account.chart.template`, o core cria a conta de transferência de
+        # liquidez, e ela já nasce classificada (ver
+        # `_prepare_transfer_account_template`). Na ordem inversa a etiqueta
+        # ainda não existiria e a conta nasceria órfã.
         "data/account.account.tag.csv",
+        "data/l10n_br_coa_template.xml",
         "data/account.tax.group.csv",
         "data/account.tax.template.csv",
         # Views

--- a/l10n_br_coa/data/account.account.tag.csv
+++ b/l10n_br_coa/data/account.account.tag.csv
@@ -66,3 +66,24 @@ l10n_br_coa.account_tag_compensation_liability,Compensação / Passivo,accounts,
 l10n_br_coa.account_tag_production_cost,Custos de Produção / Apropriação,accounts,base.br
 l10n_br_coa.account_tag_production_transfer,Custos de Produção / (-) Transferência para Estoque,accounts,base.br
 l10n_br_coa.account_tag_result,Resultado / Contas de Resultado (todas),accounts,base.br
+l10n_br_coa.account_tag_cash_and_equivalents,Fluxo de Caixa / Caixa e Equivalentes de Caixa,accounts,base.br
+l10n_br_coa.account_tag_cash_flow_operating,Fluxo de Caixa / Atividades Operacionais,accounts,base.br
+l10n_br_coa.account_tag_cash_flow_investing,Fluxo de Caixa / Atividades de Investimento,accounts,base.br
+l10n_br_coa.account_tag_cash_flow_financing,Fluxo de Caixa / Atividades de Financiamento,accounts,base.br
+l10n_br_coa.account_tag_cash_flow_non_cash,Fluxo de Caixa / Não Afeta o Caixa,accounts,base.br
+l10n_br_coa.account_tag_depreciation_expense,"Ajuste ao Resultado / Depreciação, Amortização e Exaustão",accounts,base.br
+l10n_br_coa.account_tag_provision_expense,Ajuste ao Resultado / Constituição e Reversão de Provisões,accounts,base.br
+l10n_br_coa.account_tag_equity_method_result,Ajuste ao Resultado / Resultado de Equivalência Patrimonial,accounts,base.br
+l10n_br_coa.account_tag_disposal_result,Ajuste ao Resultado / Resultado na Baixa de Ativo,accounts,base.br
+l10n_br_coa.account_tag_equity_valuation_adjustment,Patrimônio Líquido / Ajustes de Avaliação Patrimonial,accounts,base.br
+l10n_br_coa.account_tag_oci_translation,Resultado Abrangente / Variação Cambial de Investimento no Exterior,accounts,base.br
+l10n_br_coa.account_tag_oci_hedge,Resultado Abrangente / Hedge de Fluxo de Caixa,accounts,base.br
+l10n_br_coa.account_tag_oci_actuarial,Resultado Abrangente / Ganhos e Perdas Atuariais,accounts,base.br
+l10n_br_coa.account_tag_oci_fair_value,Resultado Abrangente / Ajuste a Valor Justo,accounts,base.br
+l10n_br_coa.account_tag_dva_inputs,Valor Adicionado / Insumos Adquiridos de Terceiros,accounts,base.br
+l10n_br_coa.account_tag_dva_personnel,Valor Adicionado / Pessoal,accounts,base.br
+l10n_br_coa.account_tag_dva_taxes,"Valor Adicionado / Impostos, Taxas e Contribuições",accounts,base.br
+l10n_br_coa.account_tag_dva_third_party_capital,Valor Adicionado / Remuneração de Capitais de Terceiros,accounts,base.br
+l10n_br_coa.account_tag_dva_own_capital,Valor Adicionado / Remuneração de Capitais Próprios,accounts,base.br
+l10n_br_coa.account_tag_dva_transfer,Valor Adicionado / Recebido em Transferência,accounts,base.br
+l10n_br_coa.account_tag_cash_flow_result_adjustment,Fluxo de Caixa / Neutralizado por Ajuste ao Resultado,accounts,base.br

--- a/l10n_br_coa/migrations/16.0.2.9.0/post-migration.py
+++ b/l10n_br_coa/migrations/16.0.2.9.0/post-migration.py
@@ -1,0 +1,72 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+"""Carry the classification added in this version to live accounts.
+
+Same job as the script of 16.0.2.8.0, run again because this version ships new
+tags (cash flow activity, value added distribution and the adjustments the
+indirect cash flow statement adds back). A database that stopped at the
+previous version got the tags that existed then and would never see these.
+The script is idempotent: it only adds what is missing.
+
+`account.account.template.tag_ids` only reaches `account.account` when the
+chart is loaded into a company. On a database that already loaded the chart,
+updating the module updates the template and not the account, and the reports
+would read zero, because they select by classification.
+
+The template to account mapping is the `ir.model.data` the chart load creates,
+named `{company_id}_{template xmlid}`. That is the same path the core uses to
+know which account came from which template, so it works for any chart, not
+only the two shipped by the OCA.
+
+The migration never removes an existing classification: whoever tagged an
+account by hand keeps what they did.
+"""
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    templates = env["account.account.template"].search([("tag_ids", "!=", False)])
+    if not templates:
+        return
+
+    # {template id: tag ids}
+    tags_by_template = {t.id: t.tag_ids.ids for t in templates}
+
+    data = env["ir.model.data"].search(
+        [
+            ("model", "=", "account.account.template"),
+            ("res_id", "in", list(tags_by_template)),
+        ]
+    )
+    # {full template xmlid: tag ids}
+    tags_by_xmlid = {f"{d.module}.{d.name}": tags_by_template[d.res_id] for d in data}
+    if not tags_by_xmlid:
+        return
+
+    updated = 0
+    for company in env["res.company"].search([]):
+        suffix_map = {
+            f"{company.id}_{name.split('.', 1)[1]}": tags
+            for name, tags in tags_by_xmlid.items()
+        }
+        account_data = env["ir.model.data"].search(
+            [
+                ("model", "=", "account.account"),
+                ("name", "in", list(suffix_map)),
+            ]
+        )
+        for d in account_data:
+            account = env["account.account"].browse(d.res_id).exists()
+            if not account:
+                continue
+            missing = set(suffix_map[d.name]) - set(account.tag_ids.ids)
+            if missing:
+                account.write({"tag_ids": [(4, tag_id) for tag_id in missing]})
+                updated += 1
+
+    _logger.info("l10n_br_coa: classification applied to %s existing accounts", updated)

--- a/l10n_br_coa/models/account_chart_template.py
+++ b/l10n_br_coa/models/account_chart_template.py
@@ -1,11 +1,37 @@
 # Copyright 2020 KMEE
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import _, api, models
 
 
 class AccountChartTemplate(models.Model):
     _inherit = "account.chart.template"
+
+    @api.model
+    def _prepare_transfer_account_template(self, prefix=None):
+        """A conta de transferência nasce classificada e com nome em português.
+
+        Ela não é declarada pelo plano: o core a cria sozinho ao carregar a
+        escrituração, procurando o primeiro código livre depois do
+        `transfer_account_code_prefix`. Declará-la no plano não substitui a do
+        core, faz o core criar uma SEGUNDA ao lado, porque ele desiste do
+        código que já encontrou ocupado.
+
+        O ajuste tem que ser aqui, então. Sem a classificação a conta fica de
+        fora dos relatórios contábeis, que selecionam por etiqueta, e uma
+        transferência entre bancos ainda em trânsito no fim do período apareceria
+        como diferença sem explicação no Balanço e na demonstração dos fluxos de
+        caixa. Ela é caixa e equivalentes: é conta de passagem entre duas contas
+        de liquidez.
+        """
+        vals = super()._prepare_transfer_account_template(prefix=prefix)
+        tag = self.env.ref(
+            "l10n_br_coa.account_tag_cash_and_equivalents", raise_if_not_found=False
+        )
+        if tag:
+            vals["name"] = _("Transferência entre Contas de Liquidez")
+            vals["tag_ids"] = [(4, tag.id)]
+        return vals
 
     def _prepare_all_journals(self, acc_template_ref, company, journals_dict=None):
         self.ensure_one()

--- a/l10n_br_coa/tests/__init__.py
+++ b/l10n_br_coa/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_classification

--- a/l10n_br_coa/tests/test_account_classification.py
+++ b/l10n_br_coa/tests/test_account_classification.py
@@ -1,0 +1,135 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+"""The classification of the shipped charts has to stay complete.
+
+The reports select accounts by classification, so an account that loses its tag
+does not raise: it silently drops out of the statement, and the statement stops
+tying. These tests are what turns that into a failure at build time.
+"""
+from odoo.tests import TransactionCase, tagged
+
+CASH_FLOW_TAGS = (
+    "account_tag_cash_and_equivalents",
+    "account_tag_cash_flow_operating",
+    "account_tag_cash_flow_investing",
+    "account_tag_cash_flow_financing",
+    "account_tag_cash_flow_non_cash",
+    "account_tag_cash_flow_result_adjustment",
+)
+
+DVA_TAGS = (
+    "account_tag_dva_inputs",
+    "account_tag_dva_personnel",
+    "account_tag_dva_taxes",
+    "account_tag_dva_third_party_capital",
+    "account_tag_dva_own_capital",
+    "account_tag_dva_transfer",
+)
+
+
+@tagged("post_install", "-at_install")
+class TestAccountClassification(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Only the accounts THIS localisation ships. Filtering by the module
+        # that declares them is what keeps a chart of another localisation,
+        # installed side by side, out of the assertions: it has no reason to
+        # carry Brazilian classification, and the test would fail on it.
+        data = cls.env["ir.model.data"].search(
+            [
+                ("model", "=", "account.account.template"),
+                ("module", "=like", "l10n_br_coa%"),
+            ]
+        )
+        cls.templates = (
+            cls.env["account.account.template"].browse(data.mapped("res_id")).exists()
+        )
+
+    def setUp(self):
+        super().setUp()
+        if not self.templates:
+            self.skipTest("nenhum plano de contas brasileiro instalado")
+
+    def _tag(self, name):
+        return self.env.ref("l10n_br_coa.%s" % name)
+
+    def _tagged_with(self, names):
+        ids = [self._tag(name).id for name in names]
+        return self.templates.filtered(lambda t: set(t.tag_ids.ids) & set(ids))
+
+    def test_every_account_carries_a_report_line(self):
+        """No account is left out of the balance sheet and income statement."""
+        untagged = self.templates.filtered(lambda t: not t.tag_ids)
+        self.assertFalse(
+            untagged,
+            "contas sem classificação: %s"
+            % ", ".join(f"{t.code} {t.name}" for t in untagged[:10]),
+        )
+
+    def test_balance_accounts_declare_one_cash_flow_activity(self):
+        """Every balance account says which activity it belongs to.
+
+        The cash flow statement is a reconciliation: an account with no
+        activity simply vanishes from it, and the movement it carried shows up
+        as an unexplained difference against the cash account.
+        """
+        result = self._tag("account_tag_result")
+        balance = self.templates.filtered(lambda t: result not in t.tag_ids)
+        cash_flow_ids = [self._tag(name).id for name in CASH_FLOW_TAGS]
+        for account in balance:
+            declared = set(account.tag_ids.ids) & set(cash_flow_ids)
+            self.assertEqual(
+                len(declared),
+                1,
+                "a conta {} {} declara {} atividades de fluxo de caixa, e tem "
+                "que declarar exatamente uma".format(
+                    account.code, account.name, len(declared)
+                ),
+            )
+
+    def test_a_result_account_never_declares_an_activity(self):
+        """Result accounts enter the cash flow through the result, only once.
+
+        They reach the statement as the first line, the result of the year.
+        Classifying them by activity as well would count the same amount twice,
+        and the reconciliation with cash would break by exactly that amount.
+        """
+        result = self._tag("account_tag_result")
+        cash_flow_ids = [self._tag(name).id for name in CASH_FLOW_TAGS]
+        both = self.templates.filtered(
+            lambda t: result in t.tag_ids and set(t.tag_ids.ids) & set(cash_flow_ids)
+        )
+        self.assertFalse(
+            both,
+            "contas de resultado com atividade de fluxo de caixa: {}".format(
+                ", ".join(f"{t.code} {t.name}" for t in both[:10])
+            ),
+        )
+
+    def test_expense_accounts_declare_how_they_distribute_value(self):
+        """Every cost and expense says where it lands on the value added.
+
+        The value added statement has to tie: what is distributed equals what
+        there is to distribute. An expense with no destination breaks the
+        equality the CPC 09 requires.
+        """
+        result = self._tag("account_tag_result")
+        revenue_ids = [
+            self._tag(name).id
+            for name in (
+                "account_tag_revenue",
+                "account_tag_other_operating_results",
+            )
+        ]
+        dva_ids = [self._tag(name).id for name in DVA_TAGS]
+        expenses = self.templates.filtered(
+            lambda t: result in t.tag_ids
+            and not (set(t.tag_ids.ids) & set(revenue_ids))
+        )
+        for account in expenses:
+            self.assertTrue(
+                set(account.tag_ids.ids) & set(dva_ids),
+                "a conta de resultado {} {} não diz como distribui o valor "
+                "adicionado".format(account.code, account.name),
+            )

--- a/l10n_br_coa_generic/data/account.account.template.csv
+++ b/l10n_br_coa_generic/data/account.account.template.csv
@@ -1,351 +1,351 @@
 id,code,name,note,account_type,reconcile,chart_template_id:id,tag_ids:id
-coa_generic_111101,1.1.1.1.01,Caixa Geral,,asset_cash,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_cash
-coa_generic_112101,1.1.2.1.01,Clientes,,asset_receivable,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_receivable
-coa_generic_112102,1.1.2.1.02,Controle de Débitos (POS),,asset_receivable,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_receivable
-coa_generic_112201,1.1.2.2.01,(-) Duplicatas Descontadas,,asset_receivable,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_receivable
-coa_generic_112901,1.1.2.9.01,Outros Valores a Receber,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_receivable
-coa_generic_119001,1.1.9.0.01,Estoque Intermediário (Recebido),,asset_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119002,1.1.9.0.02,Estoque Intermediário (Enviado),,asset_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113101,1.1.3.1.01,Estoque Inicial Mercadorias,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113102,1.1.3.1.02,Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113103,1.1.3.1.03,Fretes e Carretos Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113104,1.1.3.1.04,ICMS – Substituição Tributária Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113105,1.1.3.1.05,ICMS – Antecipado Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113106,1.1.3.1.06,ICMS – Diferencial de Alíquota de Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113110,1.1.3.1.10,(-) Devoluções de Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113111,1.1.3.1.11,(-) ICMS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113112,1.1.3.1.12,(-) COFINS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113113,1.1.3.1.13,(-) PIS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113119,1.1.3.1.19,(-) Custo das Mercadorias Vendidas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113120,1.1.3.1.20,(-) Custo das Mercadorias Baixas Diversas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113201,1.1.3.2.01,Estoque Inicial Produtos Acabados,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113202,1.1.3.2.02,Produção Produtos Acabados,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113209,1.1.3.2.09,(-) Custo dos Produtos Vendidos,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113210,1.1.3.2.10,(-) Custo dos Produtos Baixas Diversas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113301,1.1.3.3.01,Estoque Inicial Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113302,1.1.3.3.02,Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113303,1.1.3.3.03,Fretes e Carretos Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113304,1.1.3.3.04,ICMS – Substituição Tributária Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113305,1.1.3.3.05,ICMS – Antecipado Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113306,1.1.3.3.06,ICMS – Diferencial de Alíquota Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113310,1.1.3.3.10,(-) Devoluções de Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113311,1.1.3.3.11,(-) ICMS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113312,1.1.3.3.12,(-) COFINS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113313,1.1.3.3.13,(-) PIS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113314,1.1.3.3.14,(-) IPI sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113319,1.1.3.3.19,(-) Transferência para Consumo Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113401,1.1.3.4.01,Estoque Inicial Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113402,1.1.3.4.02,Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113403,1.1.3.4.03,Fretes e Carretos Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113404,1.1.3.4.04,ICMS – Substituição Tributária Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113405,1.1.3.4.05,ICMS – Antecipado Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113406,1.1.3.4.06,ICMS – Diferencial Alíquota de Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113410,1.1.3.4.10,(-) Devoluções de Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113411,1.1.3.4.11,(-) ICMS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113412,1.1.3.4.12,(-) COFINS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113413,1.1.3.4.13,(-) PIS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113414,1.1.3.4.14,(-) IPI sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113419,1.1.3.4.19,(-) Transferência para Consumo Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113901,1.1.3.9.01,Estoque Inicial Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113902,1.1.3.9.02,Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113903,1.1.3.9.03,Fretes e Carretos Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113904,1.1.3.9.04,ICMS – Substituição Tributária Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113905,1.1.3.9.05,ICMS – Antecipado Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113906,1.1.3.9.06,ICMS – Diferencial de Alíquota Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113910,1.1.3.9.10,(-) Devoluções de Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113911,1.1.3.9.11,(-) ICMS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113912,1.1.3.9.12,(-) COFINS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113913,1.1.3.9.13,(-) PIS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113914,1.1.3.9.14,(-) IPI sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_113919,1.1.3.9.19,(-) Transferência para Consumo Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_114101,1.1.4.1.01,IPI a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114102,1.1.4.1.02,ICMS a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114103,1.1.4.1.03,ICMS Antecipado a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114104,1.1.4.1.04,COFINS a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114105,1.1.4.1.05,PIS a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114106,1.1.4.1.06,IRPJ a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114107,1.1.4.1.07,CSLL a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114108,1.1.4.1.08,IRRF a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114109,1.1.4.1.09,ISS a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114110,1.1.4.1.10,II a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114111,1.1.4.1.11,INSS a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114112,1.1.4.1.12,IBS a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114113,1.1.4.1.13,CBS a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114114,1.1.4.1.14,IS a Compensar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114201,1.1.4.2.01,Adto Quinzenal,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114202,1.1.4.2.02,Adto Salarial,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114203,1.1.4.2.03,Adto de Férias,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114204,1.1.4.2.04,Adto de Rescisão,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114301,1.1.4.3.01,Adto à Fornecedores de Mercadorias,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114302,1.1.4.3.02,Adto à Fornecedores de Matéria Prima,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114303,1.1.4.3.03,Adto à Fornecedores de Uso e Consumo,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114304,1.1.4.3.04,Adto à Fornecedores de Despesas,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_114305,1.1.4.3.05,Adto à Fornecedores de Outros,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_115101,1.1.5.1.01,Seguros a Apropriar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_115102,1.1.5.1.02,Encargos a Apropriar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_115103,1.1.5.1.03,IPTU a Apropriar,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_other_credits
-coa_generic_119101,1.1.9.1.01,Estoque Inicial Mercadorias,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119102,1.1.9.1.02,Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119103,1.1.9.1.03,Fretes e Carretos Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119104,1.1.9.1.04,ICMS – Substituição Tributária Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119105,1.1.9.1.05,ICMS – Antecipado Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119106,1.1.9.1.06,ICMS – Diferencial de Alíquota de Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119110,1.1.9.1.10,(-) Devoluções de Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119111,1.1.9.1.11,(-) ICMS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119112,1.1.9.1.12,(-) COFINS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119113,1.1.9.1.13,(-) PIS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119119,1.1.9.1.19,(-) Custo das Mercadorias Vendidas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119120,1.1.9.1.20,(-) Custo das Mercadorias Baixas Diversas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119201,1.1.9.2.01,Estoque Inicial Produtos Acabados,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119202,1.1.9.2.02,Produção Produtos Acabados,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119209,1.1.9.2.09,(-) Custo dos Produtos Vendidos,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119210,1.1.9.2.10,(-) Custo dos Produtos Baixas Diversas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119301,1.1.9.3.01,Estoque Inicial Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119302,1.1.9.3.02,Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119303,1.1.9.3.03,Fretes e Carretos Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119304,1.1.9.3.04,ICMS – Substituição Tributária Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119305,1.1.9.3.05,ICMS – Antecipado Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119306,1.1.9.3.06,ICMS – Diferencial de Alíquota Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119310,1.1.9.3.10,(-) Devoluções de Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119311,1.1.9.3.11,(-) ICMS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119312,1.1.9.3.12,(-) COFINS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119313,1.1.9.3.13,(-) PIS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119314,1.1.9.3.14,(-) IPI sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119319,1.1.9.3.19,(-) Transferência para Consumo Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119401,1.1.9.4.01,Estoque Inicial Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119402,1.1.9.4.02,Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119403,1.1.9.4.03,Fretes e Carretos Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119404,1.1.9.4.04,ICMS – Substituição Tributária Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119405,1.1.9.4.05,ICMS – Antecipado Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119406,1.1.9.4.06,ICMS – Diferencial Alíquota de Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119410,1.1.9.4.10,(-) Devoluções de Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119411,1.1.9.4.11,(-) ICMS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119412,1.1.9.4.12,(-) COFINS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119413,1.1.9.4.13,(-) PIS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119414,1.1.9.4.14,(-) IPI sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119419,1.1.9.4.19,(-) Transferência para Consumo Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119901,1.1.9.9.01,Estoque Inicial Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119902,1.1.9.9.02,Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119903,1.1.9.9.03,Fretes e Carretos Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119904,1.1.9.9.04,ICMS – Substituição Tributária Embalagens,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119905,1.1.9.9.05,ICMS – Antecipado Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119906,1.1.9.9.06,ICMS – Diferencial de Alíquota Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119910,1.1.9.9.10,(-) Devoluções de Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119911,1.1.9.9.11,(-) ICMS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119912,1.1.9.9.12,(-) COFINS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119913,1.1.9.9.13,(-) PIS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119914,1.1.9.9.14,(-) IPI sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_119919,1.1.9.9.19,(-) Transferência para Consumo Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_assets_stock
-coa_generic_122101,1.2.2.1.01,Clientes,,asset_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_assets_receivable
-coa_generic_123101,1.2.3.1.01,ICMS Ativo Imobilizado 1/48 Avos CIAP,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_assets_receivable
-coa_generic_123102,1.2.3.1.02,PIS Ativo Imobilizado 1/24 Avos - Valor do Bem,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_assets_receivable
-coa_generic_123103,1.2.3.1.03,COFINS Ativo Imobilizado 1/24 Avos - Valor do Bem,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_assets_receivable
-coa_generic_124101,1.2.4.1.01,Seguros a Apropriar,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_assets_receivable
-coa_generic_125101,1.2.5.1.01,Depósito Ação X,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_assets_receivable
-coa_generic_126101,1.2.6.1.01,Controlada X,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_investments
-coa_generic_127101,1.2.7.1.01,Consórcio Simples A,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_investments
-coa_generic_127102,1.2.7.1.02,Cooperativa de Crédito A,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_investments
-coa_generic_128101,1.2.8.1.01,Terrenos,,asset_fixed,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets
-coa_generic_128102,1.2.8.1.02,Construções e Benfeitorias,,asset_fixed,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets
-coa_generic_128103,1.2.8.1.03,"Máquinas, Aparelhos e Equipamentos",,asset_fixed,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets
-coa_generic_128104,1.2.8.1.04,Ferramentas,,asset_fixed,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets
-coa_generic_128105,1.2.8.1.05,Matrizes,,asset_fixed,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets
-coa_generic_128106,1.2.8.1.06,Móveis & Utensílios,,asset_fixed,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets
-coa_generic_128107,1.2.8.1.07,Equipamentos de Informática,,asset_fixed,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets
-coa_generic_128108,1.2.8.1.08,Instalações Comerciais,,asset_fixed,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets
-coa_generic_128109,1.2.8.1.09,Veículos e Acessórios,,asset_fixed,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets
-coa_generic_128901,1.2.8.9.01,(-) Construções e Benfeitorias,,expense_depreciation,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-coa_generic_128902,1.2.8.9.02,"(-) Máquinas, Aparelhos e Equipamentos",,expense_depreciation,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-coa_generic_128903,1.2.8.9.03,(-) Ferramentas,,expense_depreciation,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-coa_generic_128904,1.2.8.9.04,(-) Matrizes,,expense_depreciation,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-coa_generic_128905,1.2.8.9.05,(-) Móveis & Utensílios,,expense_depreciation,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-coa_generic_128906,1.2.8.9.06,(-) Equipamentos de Informática,,expense_depreciation,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-coa_generic_128907,1.2.8.9.07,(-) Instalações Comerciais,,expense_depreciation,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-coa_generic_128908,1.2.8.9.08,(-) Veículos e Acessórios,,expense_depreciation,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-coa_generic_129101,1.2.9.1.01,Marcas e Patentes,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_intangible_assets
-coa_generic_129102,1.2.9.1.02,Sistemas Aplicativos (softwares),,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_intangible_assets
-coa_generic_129601,1.2.9.6.01,(-) Marcas e Patentes,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_intangible_assets_amortization
-coa_generic_129602,1.2.9.6.02,(-) Sistemas Aplicativos (softwares),,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_intangible_assets_amortization
-coa_generic_129801,1.2.9.8.01,Gastos de Organização e Administração,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_intangible_assets
-coa_generic_129802,1.2.9.8.02,Projetos e Desenvolvimento de Novos Produtos,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_intangible_assets
-coa_generic_129901,1.2.9.9.01,(-) Gastos de Organização e Administração,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_intangible_assets_amortization
-coa_generic_129902,1.2.9.9.02,(-) Projetos e Desenvolvimento de Novos Produtos,,asset_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_intangible_assets_amortization
-coa_generic_191101,1.9.1.1.01,Bens envidados Conserto Terceiros (5.915/6.915),,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_191102,1.9.1.1.02,Bens enviados Conserto ,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_191201,1.9.1.2.01,Produtos enviados para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_191203,1.9.1.2.03,Mercadorias enviadas para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_191204,1.9.1.2.04,Uso e Consumo enviados para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_191301,1.9.1.3.01,Remessa de Venda Produção p/ Entrega Futura (5.116/6.116),,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_191303,1.9.1.3.03,Remessa de Venda Mercadorias p/ Entrega Futura (5.117/6.117),,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_191304,1.9.1.3.04,Remessas,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_211101,2.1.1.1.01,Fornecedores,,liability_payable,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_suppliers
-coa_generic_212101,2.1.2.1.01,Aluguéis a Pagar,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_payable
-coa_generic_212102,2.1.2.1.02,Energia Elétrica a Pagar,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_payable
-coa_generic_212103,2.1.2.1.03,Telefone a Pagar,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_payable
-coa_generic_212104,2.1.2.1.04,Água e Esgotos a Pagar,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_payable
-coa_generic_213101,2.1.3.1.01,Pró-labore a Pagar,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_payable
-coa_generic_214201,2.1.4.2.01,Juros Passivos Provisão,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_payable
-coa_generic_215101,2.1.5.1.01,Salários,,liability_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_labor
-coa_generic_215102,2.1.5.1.02,Férias a Pagar,,liability_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_labor
-coa_generic_215103,2.1.5.1.03,13o Salário a Pagar,,liability_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_labor
-coa_generic_215104,2.1.5.1.04,Rescisões/Indenizações Trabalh. a Pagar,,liability_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_labor
-coa_generic_215105,2.1.5.1.05,Pensão Alimenticia a Pagar,,liability_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_labor
-coa_generic_216101,2.1.6.1.01,INSS a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_labor
-coa_generic_216102,2.1.6.1.02,FGTS a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_labor
-coa_generic_216103,2.1.6.1.03,Contribuição Sindical a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_labor
-coa_generic_216104,2.1.6.1.04,IRRF Folha a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_labor
-coa_generic_217101,2.1.7.1.01,Simples Nacional a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217102,2.1.7.1.02,IPI a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217103,2.1.7.1.03,ICMS a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217104,2.1.7.1.04,COFINS a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217105,2.1.7.1.05,PIS a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217106,2.1.7.1.06,IRPJ a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217107,2.1.7.1.07,CSLL a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217108,2.1.7.1.08,ISS a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217109,2.1.7.1.09,IRF a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217110,2.1.7.1.10,ISSF a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217111,2.1.7.1.11,ICMS Substituição Tributária a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217112,2.1.7.1.12,ICMS Diferencial de Alíquota a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217113,2.1.7.1.13,II a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217114,2.1.7.1.14,IBS a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217115,2.1.7.1.15,CBS a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_217116,2.1.7.1.16,IS a Recolher,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-coa_generic_218101,2.1.8.1.01,Férias Provisão,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_reserve
-coa_generic_218102,2.1.8.1.02,13o. Salário Provisão,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_reserve
-coa_generic_218201,2.1.8.2.01,INSS s/ Férias Provisão,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_reserve
-coa_generic_218202,2.1.8.2.02,FGTS s/ Férias Provisão,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_reserve
-coa_generic_218203,2.1.8.2.03,INSS s/ 13o. Salário Provisão,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_reserve
-coa_generic_218204,2.1.8.2.04,FGTS s/ 13o. Salário Provisão,,liability_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_current_liabilities_reserve
-coa_generic_221101,2.2.1.1.01,Banco A,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_liabilities_loan
-coa_generic_222101,2.2.2.1.01,Contas a Pagar,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_liabilities
-coa_generic_227101,2.2.7.1.01,Receitas de Obras em Andamento,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_liabilities
-coa_generic_227102,2.2.7.1.02,Vendas Entrega Futura (5.922/6.922),,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_liabilities
-coa_generic_227201,2.2.7.2.01,(-) Custos de Obras em Andamento,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_liabilities
-coa_generic_227202,2.2.7.2.02,(-) CMPV- Vendas para Entrega Futura (5.922/6.922),,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_liabilities
-coa_generic_227301,2.2.7.3.01,(-) Despesas de Obras em Andamento,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_non_current_liabilities
-coa_generic_241101,2.4.1.1.01,Capital Nacional,,equity,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_capital
-coa_generic_241201,2.4.1.2.01,Sócio A,,equity,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_capital
-coa_generic_242101,2.4.2.1.01,Reserva de Incentivos Fiscais,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_capital_reserve
-coa_generic_242201,2.4.2.2.01,Variações de Elementos Ativos,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_capital_reserve
-coa_generic_242202,2.4.2.2.02,Variações de Elementos Passivos,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_capital_reserve
-coa_generic_242301,2.4.2.3.01,Retenções de Lucros,,equity,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_profit_reserve
-coa_generic_242302,2.4.2.3.02,Lucros a Realizar,,equity,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_profit_reserve
-coa_generic_243101,2.4.3.1.01,Quotas de Capital Realizado,,equity,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_profit_reserve
-coa_generic_244101,2.4.4.1.01,Lucros Acumulados,,equity,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_accumulated_profits
-coa_generic_244102,2.4.4.1.02,Prejuízos Acumulados,,equity,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_equity_accumulated_losses
-coa_generic_291101,2.9.1.1.01,NFS Bens envidados Conserto Terceiros (5.915/6.915),,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_291103,2.9.1.1.03,NFS Bens envidados,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_291201,2.9.1.2.01,NFS Produtos enviados para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_291203,2.9.1.2.03,NFS Mercadorias enviadas para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_291204,2.9.1.2.04,NFS Uso e Consumo enviados para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_291301,2.9.1.3.01,NFS Remessa de Venda Produção p/ Entrega Futura (5.116/6.116),,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_291302,2.9.1.3.02,NFS Remessa de Venda Mercadorias p/ Entrega Futura (5.117/6.117),,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_291303,2.9.1.3.03,NFS Remessas,,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_291401,2.9.1.4.01,NFS Remessa Producao a Ordem  (5.923),,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_291402,2.9.1.4.02,NFS Remessa Revenda a Ordem  (6.923),,liability_non_current,1,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_liability
-coa_generic_311101,3.1.1.1.01,Matérias-primas,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311102,3.1.1.1.02,Materiais de embalagem,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311201,3.1.1.2.01,Salários,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311202,3.1.1.2.02,Encargos Sociais,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311203,3.1.1.2.03,Vale Transporte,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311204,3.1.1.2.04,Refeições,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311205,3.1.1.2.05,Uniformes,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311206,3.1.1.2.06,Assistência Médica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311301,3.1.1.3.01,Materiais de consumo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311901,3.1.1.9.01,Salários,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311902,3.1.1.9.02,Encargos Sociais,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311903,3.1.1.9.03,Vale Transporte,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311904,3.1.1.9.04,Refeições,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311905,3.1.1.9.05,Uniformes,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311906,3.1.1.9.06,Assistência Médica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311910,3.1.1.9.10,Energia elétrica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311911,3.1.1.9.11,Manutenção,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311912,3.1.1.9.12,Aluguel de bens imóveis,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311913,3.1.1.9.13,Locação de bens móveis,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311914,3.1.1.9.14,Água e Esgoto,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311915,3.1.1.9.15,Materiais de consumo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311990,3.1.1.9.90,Prêmios de Seguro,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_311991,3.1.1.9.91,Depreciação e Amortização,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312101,3.1.2.1.01,Materiais Aplicados,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312201,3.1.2.2.01,Salários,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312202,3.1.2.2.02,Encargos Sociais,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312203,3.1.2.2.03,Vale Transporte,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312204,3.1.2.2.04,Refeições,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312205,3.1.2.2.05,Uniformes,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312206,3.1.2.2.06,Assistência Médica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312301,3.1.2.3.01,Materiais de consumo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312901,3.1.2.9.01,Salários,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312902,3.1.2.9.02,Encargos Sociais,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312903,3.1.2.9.03,Vale Transporte,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312904,3.1.2.9.04,Refeições,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312905,3.1.2.9.05,Uniformes,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312906,3.1.2.9.06,Assistência Médica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312910,3.1.2.9.10,Energia elétrica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312911,3.1.2.9.11,Manutenção,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312912,3.1.2.9.12,Aluguel de bens imóveis,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312913,3.1.2.9.13,Locação de bens móveis,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312914,3.1.2.9.14,Água e Esgoto,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312915,3.1.2.9.15,Materiais de consumo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312916,3.1.2.9.16,Ferramentas,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312990,3.1.2.9.90,Prêmios de Seguro,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_312991,3.1.2.9.91,Depreciação e Amortização,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result"
-coa_generic_411101,4.1.1.1.01,(-) De Bens,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_transfer,l10n_br_coa.account_tag_result"
-coa_generic_411102,4.1.1.1.02,(-) De Serviços,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_transfer,l10n_br_coa.account_tag_result"
-coa_generic_411103,4.1.1.1.03,(-) Produto Acabado,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_transfer,l10n_br_coa.account_tag_result"
-coa_generic_511101,5.1.1.1.01,Custo das Mercadorias Vendidas,,expense_direct_cost,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result"
-coa_generic_511102,5.1.1.1.02,Custo dos Produtos Vendidos,,expense_direct_cost,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result"
-coa_generic_511103,5.1.1.1.03,Custo dos Serviços Prestados,,expense_direct_cost,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result"
-coa_generic_511104,5.1.1.1.04,Custo de Perdas/Brindes/Bonificações,,expense_direct_cost,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result"
-coa_generic_511201,5.1.1.2.01,Salários,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511202,5.1.1.2.02,Encargos Sociais,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511203,5.1.1.2.03,Vale Transporte,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511204,5.1.1.2.04,Refeições,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511205,5.1.1.2.05,Uniformes,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511206,5.1.1.2.06,Assistência Médica,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511301,5.1.1.3.01,Pró-labore,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511302,5.1.1.3.02,Aluguel de Imóveis,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511303,5.1.1.3.03,Locação de Bens,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511304,5.1.1.3.04,Energia Elétrica,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511305,5.1.1.3.05,Telefone e Internet,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511306,5.1.1.3.06,Água e Esgoto,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511307,5.1.1.3.07,Tarifas Bancárias,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511308,5.1.1.3.08,Material de Consumo,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511309,5.1.1.3.09,Material de Expediente,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511310,5.1.1.3.10,Correios,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511401,5.1.1.4.01,Fretes e Carretos,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511402,5.1.1.4.02,Comissões e Corretagens,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511403,5.1.1.4.03,Despesas de Viagens e Estadas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511404,5.1.1.4.04,Despesas com Marketing,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511405,5.1.1.4.05,Bonificações (CFOP 5.910),,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511406,5.1.1.4.06,Bonificações (CFOP 6.910),,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511501,5.1.1.5.01,IPTU,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511502,5.1.1.5.02,IPVA,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511503,5.1.1.5.03,IOF,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511504,5.1.1.5.04,Multas Fiscais Dedutíveis,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511505,5.1.1.5.05,COFINS s/Outras Receitas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511506,5.1.1.5.06,PIS s/Outras Receitas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511507,5.1.1.5.07,IRPJ s/Aplicações Financeiras,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511508,5.1.1.5.08,Impostos e Taxas Diversas Federais,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511509,5.1.1.5.09,Impostos e Taxas Diversas Estaduais,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511510,5.1.1.5.10,Impostos e Taxas Diversas Municipais,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511511,5.1.1.5.11,ICMS s/ Outras Receitas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511601,5.1.1.6.01,Juros Passivos,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-coa_generic_511602,5.1.1.6.02,Juros de Mora,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-coa_generic_511603,5.1.1.6.03,Descontos Concedidos,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-coa_generic_511604,5.1.1.6.04,Variações Monetárias Passivas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-coa_generic_511605,5.1.1.6.05,Variações Cambiais Passivas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-coa_generic_511701,5.1.1.7.01,Depreciação,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511702,5.1.1.7.02,Amortização,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
-coa_generic_511801,5.1.1.8.01,Perdas por Insolvência,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result"
+coa_generic_111101,1.1.1.1.01,Caixa Geral,,asset_cash,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_cash,l10n_br_coa.account_tag_cash_and_equivalents"
+coa_generic_112101,1.1.2.1.01,Clientes,,asset_receivable,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_112102,1.1.2.1.02,Controle de Débitos (POS),,asset_receivable,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_112201,1.1.2.2.01,(-) Duplicatas Descontadas,,asset_receivable,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_112901,1.1.2.9.01,Outros Valores a Receber,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119001,1.1.9.0.01,Estoque Intermediário (Recebido),,asset_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119002,1.1.9.0.02,Estoque Intermediário (Enviado),,asset_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113101,1.1.3.1.01,Estoque Inicial Mercadorias,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113102,1.1.3.1.02,Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113103,1.1.3.1.03,Fretes e Carretos Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113104,1.1.3.1.04,ICMS – Substituição Tributária Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113105,1.1.3.1.05,ICMS – Antecipado Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113106,1.1.3.1.06,ICMS – Diferencial de Alíquota de Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113110,1.1.3.1.10,(-) Devoluções de Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113111,1.1.3.1.11,(-) ICMS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113112,1.1.3.1.12,(-) COFINS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113113,1.1.3.1.13,(-) PIS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113119,1.1.3.1.19,(-) Custo das Mercadorias Vendidas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113120,1.1.3.1.20,(-) Custo das Mercadorias Baixas Diversas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113201,1.1.3.2.01,Estoque Inicial Produtos Acabados,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113202,1.1.3.2.02,Produção Produtos Acabados,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113209,1.1.3.2.09,(-) Custo dos Produtos Vendidos,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113210,1.1.3.2.10,(-) Custo dos Produtos Baixas Diversas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113301,1.1.3.3.01,Estoque Inicial Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113302,1.1.3.3.02,Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113303,1.1.3.3.03,Fretes e Carretos Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113304,1.1.3.3.04,ICMS – Substituição Tributária Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113305,1.1.3.3.05,ICMS – Antecipado Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113306,1.1.3.3.06,ICMS – Diferencial de Alíquota Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113310,1.1.3.3.10,(-) Devoluções de Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113311,1.1.3.3.11,(-) ICMS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113312,1.1.3.3.12,(-) COFINS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113313,1.1.3.3.13,(-) PIS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113314,1.1.3.3.14,(-) IPI sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113319,1.1.3.3.19,(-) Transferência para Consumo Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113401,1.1.3.4.01,Estoque Inicial Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113402,1.1.3.4.02,Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113403,1.1.3.4.03,Fretes e Carretos Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113404,1.1.3.4.04,ICMS – Substituição Tributária Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113405,1.1.3.4.05,ICMS – Antecipado Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113406,1.1.3.4.06,ICMS – Diferencial Alíquota de Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113410,1.1.3.4.10,(-) Devoluções de Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113411,1.1.3.4.11,(-) ICMS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113412,1.1.3.4.12,(-) COFINS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113413,1.1.3.4.13,(-) PIS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113414,1.1.3.4.14,(-) IPI sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113419,1.1.3.4.19,(-) Transferência para Consumo Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113901,1.1.3.9.01,Estoque Inicial Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113902,1.1.3.9.02,Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113903,1.1.3.9.03,Fretes e Carretos Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113904,1.1.3.9.04,ICMS – Substituição Tributária Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113905,1.1.3.9.05,ICMS – Antecipado Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113906,1.1.3.9.06,ICMS – Diferencial de Alíquota Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113910,1.1.3.9.10,(-) Devoluções de Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113911,1.1.3.9.11,(-) ICMS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113912,1.1.3.9.12,(-) COFINS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113913,1.1.3.9.13,(-) PIS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113914,1.1.3.9.14,(-) IPI sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_113919,1.1.3.9.19,(-) Transferência para Consumo Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114101,1.1.4.1.01,IPI a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114102,1.1.4.1.02,ICMS a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114103,1.1.4.1.03,ICMS Antecipado a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114104,1.1.4.1.04,COFINS a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114105,1.1.4.1.05,PIS a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114106,1.1.4.1.06,IRPJ a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114107,1.1.4.1.07,CSLL a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114108,1.1.4.1.08,IRRF a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114109,1.1.4.1.09,ISS a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114110,1.1.4.1.10,II a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114111,1.1.4.1.11,INSS a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114112,1.1.4.1.12,IBS a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114113,1.1.4.1.13,CBS a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114114,1.1.4.1.14,IS a Compensar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114201,1.1.4.2.01,Adto Quinzenal,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114202,1.1.4.2.02,Adto Salarial,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114203,1.1.4.2.03,Adto de Férias,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114204,1.1.4.2.04,Adto de Rescisão,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114301,1.1.4.3.01,Adto à Fornecedores de Mercadorias,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114302,1.1.4.3.02,Adto à Fornecedores de Matéria Prima,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114303,1.1.4.3.03,Adto à Fornecedores de Uso e Consumo,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114304,1.1.4.3.04,Adto à Fornecedores de Despesas,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_114305,1.1.4.3.05,Adto à Fornecedores de Outros,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_115101,1.1.5.1.01,Seguros a Apropriar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_115102,1.1.5.1.02,Encargos a Apropriar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_115103,1.1.5.1.03,IPTU a Apropriar,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119101,1.1.9.1.01,Estoque Inicial Mercadorias,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119102,1.1.9.1.02,Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119103,1.1.9.1.03,Fretes e Carretos Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119104,1.1.9.1.04,ICMS – Substituição Tributária Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119105,1.1.9.1.05,ICMS – Antecipado Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119106,1.1.9.1.06,ICMS – Diferencial de Alíquota de Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119110,1.1.9.1.10,(-) Devoluções de Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119111,1.1.9.1.11,(-) ICMS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119112,1.1.9.1.12,(-) COFINS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119113,1.1.9.1.13,(-) PIS sobre Compras Mercadorias,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119119,1.1.9.1.19,(-) Custo das Mercadorias Vendidas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119120,1.1.9.1.20,(-) Custo das Mercadorias Baixas Diversas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119201,1.1.9.2.01,Estoque Inicial Produtos Acabados,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119202,1.1.9.2.02,Produção Produtos Acabados,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119209,1.1.9.2.09,(-) Custo dos Produtos Vendidos,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119210,1.1.9.2.10,(-) Custo dos Produtos Baixas Diversas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119301,1.1.9.3.01,Estoque Inicial Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119302,1.1.9.3.02,Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119303,1.1.9.3.03,Fretes e Carretos Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119304,1.1.9.3.04,ICMS – Substituição Tributária Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119305,1.1.9.3.05,ICMS – Antecipado Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119306,1.1.9.3.06,ICMS – Diferencial de Alíquota Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119310,1.1.9.3.10,(-) Devoluções de Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119311,1.1.9.3.11,(-) ICMS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119312,1.1.9.3.12,(-) COFINS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119313,1.1.9.3.13,(-) PIS sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119314,1.1.9.3.14,(-) IPI sobre Compras Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119319,1.1.9.3.19,(-) Transferência para Consumo Matérias Primas,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119401,1.1.9.4.01,Estoque Inicial Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119402,1.1.9.4.02,Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119403,1.1.9.4.03,Fretes e Carretos Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119404,1.1.9.4.04,ICMS – Substituição Tributária Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119405,1.1.9.4.05,ICMS – Antecipado Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119406,1.1.9.4.06,ICMS – Diferencial Alíquota de Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119410,1.1.9.4.10,(-) Devoluções de Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119411,1.1.9.4.11,(-) ICMS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119412,1.1.9.4.12,(-) COFINS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119413,1.1.9.4.13,(-) PIS sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119414,1.1.9.4.14,(-) IPI sobre Compras Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119419,1.1.9.4.19,(-) Transferência para Consumo Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119901,1.1.9.9.01,Estoque Inicial Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119902,1.1.9.9.02,Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119903,1.1.9.9.03,Fretes e Carretos Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119904,1.1.9.9.04,ICMS – Substituição Tributária Embalagens,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119905,1.1.9.9.05,ICMS – Antecipado Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119906,1.1.9.9.06,ICMS – Diferencial de Alíquota Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119910,1.1.9.9.10,(-) Devoluções de Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119911,1.1.9.9.11,(-) ICMS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119912,1.1.9.9.12,(-) COFINS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119913,1.1.9.9.13,(-) PIS sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119914,1.1.9.9.14,(-) IPI sobre Compras Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_119919,1.1.9.9.19,(-) Transferência para Consumo Uso e Consumo,,asset_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_122101,1.2.2.1.01,Clientes,,asset_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_123101,1.2.3.1.01,ICMS Ativo Imobilizado 1/48 Avos CIAP,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_123102,1.2.3.1.02,PIS Ativo Imobilizado 1/24 Avos - Valor do Bem,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_123103,1.2.3.1.03,COFINS Ativo Imobilizado 1/24 Avos - Valor do Bem,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_124101,1.2.4.1.01,Seguros a Apropriar,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_125101,1.2.5.1.01,Depósito Ação X,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_126101,1.2.6.1.01,Controlada X,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_investments,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_127101,1.2.7.1.01,Consórcio Simples A,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_investments,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_127102,1.2.7.1.02,Cooperativa de Crédito A,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_investments,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128101,1.2.8.1.01,Terrenos,,asset_fixed,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128102,1.2.8.1.02,Construções e Benfeitorias,,asset_fixed,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128103,1.2.8.1.03,"Máquinas, Aparelhos e Equipamentos",,asset_fixed,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128104,1.2.8.1.04,Ferramentas,,asset_fixed,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128105,1.2.8.1.05,Matrizes,,asset_fixed,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128106,1.2.8.1.06,Móveis & Utensílios,,asset_fixed,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128107,1.2.8.1.07,Equipamentos de Informática,,asset_fixed,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128108,1.2.8.1.08,Instalações Comerciais,,asset_fixed,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128109,1.2.8.1.09,Veículos e Acessórios,,asset_fixed,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_128901,1.2.8.9.01,(-) Construções e Benfeitorias,,expense_depreciation,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_128902,1.2.8.9.02,"(-) Máquinas, Aparelhos e Equipamentos",,expense_depreciation,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_128903,1.2.8.9.03,(-) Ferramentas,,expense_depreciation,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_128904,1.2.8.9.04,(-) Matrizes,,expense_depreciation,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_128905,1.2.8.9.05,(-) Móveis & Utensílios,,expense_depreciation,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_128906,1.2.8.9.06,(-) Equipamentos de Informática,,expense_depreciation,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_128907,1.2.8.9.07,(-) Instalações Comerciais,,expense_depreciation,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_128908,1.2.8.9.08,(-) Veículos e Acessórios,,expense_depreciation,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_129101,1.2.9.1.01,Marcas e Patentes,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_129102,1.2.9.1.02,Sistemas Aplicativos (softwares),,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_129601,1.2.9.6.01,(-) Marcas e Patentes,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_intangible_assets_amortization,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_129602,1.2.9.6.02,(-) Sistemas Aplicativos (softwares),,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_intangible_assets_amortization,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_129801,1.2.9.8.01,Gastos de Organização e Administração,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_129802,1.2.9.8.02,Projetos e Desenvolvimento de Novos Produtos,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+coa_generic_129901,1.2.9.9.01,(-) Gastos de Organização e Administração,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_intangible_assets_amortization,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_129902,1.2.9.9.02,(-) Projetos e Desenvolvimento de Novos Produtos,,asset_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_intangible_assets_amortization,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+coa_generic_191101,1.9.1.1.01,Bens envidados Conserto Terceiros (5.915/6.915),,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_191102,1.9.1.1.02,Bens enviados Conserto ,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_191201,1.9.1.2.01,Produtos enviados para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_191203,1.9.1.2.03,Mercadorias enviadas para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_191204,1.9.1.2.04,Uso e Consumo enviados para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_191301,1.9.1.3.01,Remessa de Venda Produção p/ Entrega Futura (5.116/6.116),,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_191303,1.9.1.3.03,Remessa de Venda Mercadorias p/ Entrega Futura (5.117/6.117),,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_191304,1.9.1.3.04,Remessas,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_211101,2.1.1.1.01,Fornecedores,,liability_payable,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_suppliers,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_212101,2.1.2.1.01,Aluguéis a Pagar,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_212102,2.1.2.1.02,Energia Elétrica a Pagar,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_212103,2.1.2.1.03,Telefone a Pagar,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_212104,2.1.2.1.04,Água e Esgotos a Pagar,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_213101,2.1.3.1.01,Pró-labore a Pagar,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_214201,2.1.4.2.01,Juros Passivos Provisão,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_215101,2.1.5.1.01,Salários,,liability_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_215102,2.1.5.1.02,Férias a Pagar,,liability_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_215103,2.1.5.1.03,13o Salário a Pagar,,liability_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_215104,2.1.5.1.04,Rescisões/Indenizações Trabalh. a Pagar,,liability_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_215105,2.1.5.1.05,Pensão Alimenticia a Pagar,,liability_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_216101,2.1.6.1.01,INSS a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_216102,2.1.6.1.02,FGTS a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_216103,2.1.6.1.03,Contribuição Sindical a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_216104,2.1.6.1.04,IRRF Folha a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217101,2.1.7.1.01,Simples Nacional a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217102,2.1.7.1.02,IPI a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217103,2.1.7.1.03,ICMS a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217104,2.1.7.1.04,COFINS a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217105,2.1.7.1.05,PIS a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217106,2.1.7.1.06,IRPJ a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217107,2.1.7.1.07,CSLL a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217108,2.1.7.1.08,ISS a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217109,2.1.7.1.09,IRF a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217110,2.1.7.1.10,ISSF a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217111,2.1.7.1.11,ICMS Substituição Tributária a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217112,2.1.7.1.12,ICMS Diferencial de Alíquota a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217113,2.1.7.1.13,II a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217114,2.1.7.1.14,IBS a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217115,2.1.7.1.15,CBS a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_217116,2.1.7.1.16,IS a Recolher,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_218101,2.1.8.1.01,Férias Provisão,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_reserve,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_218102,2.1.8.1.02,13o. Salário Provisão,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_reserve,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_218201,2.1.8.2.01,INSS s/ Férias Provisão,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_reserve,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_218202,2.1.8.2.02,FGTS s/ Férias Provisão,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_reserve,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_218203,2.1.8.2.03,INSS s/ 13o. Salário Provisão,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_reserve,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_218204,2.1.8.2.04,FGTS s/ 13o. Salário Provisão,,liability_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_current_liabilities_reserve,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_221101,2.2.1.1.01,Banco A,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_liabilities_loan,l10n_br_coa.account_tag_cash_flow_financing"
+coa_generic_222101,2.2.2.1.01,Contas a Pagar,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_227101,2.2.7.1.01,Receitas de Obras em Andamento,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_227102,2.2.7.1.02,Vendas Entrega Futura (5.922/6.922),,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_227201,2.2.7.2.01,(-) Custos de Obras em Andamento,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_227202,2.2.7.2.02,(-) CMPV- Vendas para Entrega Futura (5.922/6.922),,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_227301,2.2.7.3.01,(-) Despesas de Obras em Andamento,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+coa_generic_241101,2.4.1.1.01,Capital Nacional,,equity,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_capital,l10n_br_coa.account_tag_cash_flow_financing"
+coa_generic_241201,2.4.1.2.01,Sócio A,,equity,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_capital,l10n_br_coa.account_tag_cash_flow_financing"
+coa_generic_242101,2.4.2.1.01,Reserva de Incentivos Fiscais,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_capital_reserve,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_242201,2.4.2.2.01,Variações de Elementos Ativos,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_capital_reserve,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_242202,2.4.2.2.02,Variações de Elementos Passivos,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_capital_reserve,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_242301,2.4.2.3.01,Retenções de Lucros,,equity,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_profit_reserve,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_242302,2.4.2.3.02,Lucros a Realizar,,equity,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_profit_reserve,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_243101,2.4.3.1.01,Quotas de Capital Realizado,,equity,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_profit_reserve,l10n_br_coa.account_tag_cash_flow_financing"
+coa_generic_244101,2.4.4.1.01,Lucros Acumulados,,equity,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_accumulated_profits,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_244102,2.4.4.1.02,Prejuízos Acumulados,,equity,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_equity_accumulated_losses,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291101,2.9.1.1.01,NFS Bens envidados Conserto Terceiros (5.915/6.915),,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291103,2.9.1.1.03,NFS Bens envidados,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291201,2.9.1.2.01,NFS Produtos enviados para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291203,2.9.1.2.03,NFS Mercadorias enviadas para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291204,2.9.1.2.04,NFS Uso e Consumo enviados para Armazenagem ,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291301,2.9.1.3.01,NFS Remessa de Venda Produção p/ Entrega Futura (5.116/6.116),,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291302,2.9.1.3.02,NFS Remessa de Venda Mercadorias p/ Entrega Futura (5.117/6.117),,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291303,2.9.1.3.03,NFS Remessas,,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291401,2.9.1.4.01,NFS Remessa Producao a Ordem  (5.923),,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_291402,2.9.1.4.02,NFS Remessa Revenda a Ordem  (6.923),,liability_non_current,1,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_liability,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_311101,3.1.1.1.01,Matérias-primas,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_311102,3.1.1.1.02,Materiais de embalagem,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_311201,3.1.1.2.01,Salários,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311202,3.1.1.2.02,Encargos Sociais,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311203,3.1.1.2.03,Vale Transporte,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311204,3.1.1.2.04,Refeições,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311205,3.1.1.2.05,Uniformes,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311206,3.1.1.2.06,Assistência Médica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311301,3.1.1.3.01,Materiais de consumo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_311901,3.1.1.9.01,Salários,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311902,3.1.1.9.02,Encargos Sociais,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311903,3.1.1.9.03,Vale Transporte,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311904,3.1.1.9.04,Refeições,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311905,3.1.1.9.05,Uniformes,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311906,3.1.1.9.06,Assistência Médica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_311910,3.1.1.9.10,Energia elétrica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_311911,3.1.1.9.11,Manutenção,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_311912,3.1.1.9.12,Aluguel de bens imóveis,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_311913,3.1.1.9.13,Locação de bens móveis,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_311914,3.1.1.9.14,Água e Esgoto,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_311915,3.1.1.9.15,Materiais de consumo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_311990,3.1.1.9.90,Prêmios de Seguro,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_311991,3.1.1.9.91,Depreciação e Amortização,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs,l10n_br_coa.account_tag_depreciation_expense"
+coa_generic_312101,3.1.2.1.01,Materiais Aplicados,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_312201,3.1.2.2.01,Salários,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312202,3.1.2.2.02,Encargos Sociais,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312203,3.1.2.2.03,Vale Transporte,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312204,3.1.2.2.04,Refeições,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312205,3.1.2.2.05,Uniformes,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312206,3.1.2.2.06,Assistência Médica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312301,3.1.2.3.01,Materiais de consumo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_312901,3.1.2.9.01,Salários,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312902,3.1.2.9.02,Encargos Sociais,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312903,3.1.2.9.03,Vale Transporte,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312904,3.1.2.9.04,Refeições,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312905,3.1.2.9.05,Uniformes,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312906,3.1.2.9.06,Assistência Médica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_312910,3.1.2.9.10,Energia elétrica,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_312911,3.1.2.9.11,Manutenção,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_312912,3.1.2.9.12,Aluguel de bens imóveis,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_312913,3.1.2.9.13,Locação de bens móveis,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_312914,3.1.2.9.14,Água e Esgoto,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_312915,3.1.2.9.15,Materiais de consumo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_312916,3.1.2.9.16,Ferramentas,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_312990,3.1.2.9.90,Prêmios de Seguro,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_312991,3.1.2.9.91,Depreciação e Amortização,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_cost,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs,l10n_br_coa.account_tag_depreciation_expense"
+coa_generic_411101,4.1.1.1.01,(-) De Bens,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_transfer,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_411102,4.1.1.1.02,(-) De Serviços,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_transfer,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_411103,4.1.1.1.03,(-) Produto Acabado,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_production_transfer,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511101,5.1.1.1.01,Custo das Mercadorias Vendidas,,expense_direct_cost,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511102,5.1.1.1.02,Custo dos Produtos Vendidos,,expense_direct_cost,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511103,5.1.1.1.03,Custo dos Serviços Prestados,,expense_direct_cost,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511104,5.1.1.1.04,Custo de Perdas/Brindes/Bonificações,,expense_direct_cost,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511201,5.1.1.2.01,Salários,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_511202,5.1.1.2.02,Encargos Sociais,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_511203,5.1.1.2.03,Vale Transporte,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_511204,5.1.1.2.04,Refeições,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_511205,5.1.1.2.05,Uniformes,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_511206,5.1.1.2.06,Assistência Médica,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_511301,5.1.1.3.01,Pró-labore,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+coa_generic_511302,5.1.1.3.02,Aluguel de Imóveis,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_511303,5.1.1.3.03,Locação de Bens,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_511304,5.1.1.3.04,Energia Elétrica,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511305,5.1.1.3.05,Telefone e Internet,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511306,5.1.1.3.06,Água e Esgoto,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511307,5.1.1.3.07,Tarifas Bancárias,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511308,5.1.1.3.08,Material de Consumo,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511309,5.1.1.3.09,Material de Expediente,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511310,5.1.1.3.10,Correios,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511401,5.1.1.4.01,Fretes e Carretos,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511402,5.1.1.4.02,Comissões e Corretagens,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511403,5.1.1.4.03,Despesas de Viagens e Estadas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511404,5.1.1.4.04,Despesas com Marketing,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511405,5.1.1.4.05,Bonificações (CFOP 5.910),,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511406,5.1.1.4.06,Bonificações (CFOP 6.910),,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+coa_generic_511501,5.1.1.5.01,IPTU,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511502,5.1.1.5.02,IPVA,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511503,5.1.1.5.03,IOF,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511504,5.1.1.5.04,Multas Fiscais Dedutíveis,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511505,5.1.1.5.05,COFINS s/Outras Receitas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511506,5.1.1.5.06,PIS s/Outras Receitas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511507,5.1.1.5.07,IRPJ s/Aplicações Financeiras,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511508,5.1.1.5.08,Impostos e Taxas Diversas Federais,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511509,5.1.1.5.09,Impostos e Taxas Diversas Estaduais,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511510,5.1.1.5.10,Impostos e Taxas Diversas Municipais,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511511,5.1.1.5.11,ICMS s/ Outras Receitas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_511601,5.1.1.6.01,Juros Passivos,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_511602,5.1.1.6.02,Juros de Mora,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_511603,5.1.1.6.03,Descontos Concedidos,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_511604,5.1.1.6.04,Variações Monetárias Passivas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_511605,5.1.1.6.05,Variações Cambiais Passivas,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+coa_generic_511701,5.1.1.7.01,Depreciação,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs,l10n_br_coa.account_tag_depreciation_expense"
+coa_generic_511702,5.1.1.7.02,Amortização,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs,l10n_br_coa.account_tag_depreciation_expense"
+coa_generic_511801,5.1.1.8.01,Perdas por Insolvência,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_general_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs,l10n_br_coa.account_tag_provision_expense"
 coa_generic_512101,5.1.2.1.01,Multas de Trânsito,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
 coa_generic_512102,5.1.2.1.02,Multas Fiscais,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
 coa_generic_512103,5.1.2.1.03,Gastos com Festividades,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
 coa_generic_512104,5.1.2.1.04,Brindes (CFOP 5910),,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
 coa_generic_512105,5.1.2.1.05,Brindes (CFOP 6910),,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
-coa_generic_512201,5.1.2.2.01,Valor residual de Ativo Permanente Vendido,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
-coa_generic_512202,5.1.2.2.02,Valor residual de Ativo Permanente Baixado,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
-coa_generic_513101,5.1.3.1.01,Provisão para o Imposto de Renda da Pessoa Jurídica,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expense_irpj,l10n_br_coa.account_tag_result"
-coa_generic_513102,5.1.3.1.02,Provisão para a Contribuição Social sobre o Lucro Líquido,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expense_csll,l10n_br_coa.account_tag_result"
+coa_generic_512201,5.1.2.2.01,Valor residual de Ativo Permanente Vendido,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_disposal_result"
+coa_generic_512202,5.1.2.2.02,Valor residual de Ativo Permanente Baixado,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_disposal_result"
+coa_generic_513101,5.1.3.1.01,Provisão para o Imposto de Renda da Pessoa Jurídica,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expense_irpj,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes,l10n_br_coa.account_tag_provision_expense"
+coa_generic_513102,5.1.3.1.02,Provisão para a Contribuição Social sobre o Lucro Líquido,,expense,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_expense_csll,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes,l10n_br_coa.account_tag_provision_expense"
 coa_generic_611101,6.1.1.1.01,Vendas de Mercadorias,,income,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue,l10n_br_coa.account_tag_result"
 coa_generic_611102,6.1.1.1.02,Vendas de Mercadorias com Substituição Tributária,,income,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue,l10n_br_coa.account_tag_result"
 coa_generic_611103,6.1.1.1.03,Vendas de Mercadorias para o Exterior,,income,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue,l10n_br_coa.account_tag_result"
@@ -357,43 +357,43 @@ coa_generic_611121,6.1.1.1.21,Vendas de Serviços Prestados com Substituição T
 coa_generic_611122,6.1.1.1.22,Vendas de Serviços Prestados para o Exterior,,income,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue,l10n_br_coa.account_tag_result"
 coa_generic_611130,6.1.1.1.30,Entrega de Venda Fabrigação Própria p/ Entrega Futura (5.116/6.116),,income,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue,l10n_br_coa.account_tag_result"
 coa_generic_611131,6.1.1.1.31,Entrega de Venda Mercadorias p/ Entrega Futura (5.117/6.117),,income,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue,l10n_br_coa.account_tag_result"
-coa_generic_611201,6.1.1.2.01,Simples Nacional s/ Faturamento,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611202,6.1.1.2.02,ISS Substituição Tributária s/ Prestação de Serviços,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611203,6.1.1.2.03,ICMS s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611204,6.1.1.2.04,ISS s/ Prestação de Serviços,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611205,6.1.1.2.05,COFINS s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611206,6.1.1.2.06,PIS s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611207,6.1.1.2.07,ICMS ST s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611208,6.1.1.2.08,IPI s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611209,6.1.1.2.09,CSLL s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611210,6.1.1.2.10,IRPJ s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611211,6.1.1.2.11,II s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611221,6.1.1.2.21,(-)  Simples Nacional Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611222,6.1.1.2.22,(-)  ISS Substituição Tributária Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611223,6.1.1.2.23,(-)  ICMS Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611224,6.1.1.2.24,(-)  ISS Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611225,6.1.1.2.25,(-)  COFINS Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611226,6.1.1.2.26,(-)  PIS Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611227,6.1.1.2.27,(-)  ICMS ST Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611228,6.1.1.2.28,(-)  IPI Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611229,6.1.1.2.29,(-)  CSLL Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611230,6.1.1.2.30,(-)  IRPJ Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611231,6.1.1.2.31,(-)  II Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611301,6.1.1.3.01,(-) Devolução de Vendas de Mercadorias,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611302,6.1.1.3.02,(-) Devolução de Vendas de Mercadorias com Substituição Tributária,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611303,6.1.1.3.03,(-) Devolução de Vendas de Mercadorias para o Exterior,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611304,6.1.1.3.04,(-) Devolução de Vendas de Produtos de Fabricação Própria,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611305,6.1.1.3.05,(-) Devolução de Vendas de Produtos de Fabricação Própria com Substituição Tributária,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611306,6.1.1.3.06,(-) Devolução de Vendas de Produtos de Fabricação Própria para o Exterior,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611307,6.1.1.3.07,(-) Anulação de Vendas de Serviços Prestados,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611308,6.1.1.3.08,(-) Anulação Vendas de Serviços Prestados com Substituição Tributária,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_611309,6.1.1.3.09,(-) Anulação Vendas de Serviços Prestados para o Exterior,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-coa_generic_612101,6.1.2.1.01,Juros Ativos,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_financial,l10n_br_coa.account_tag_result"
-coa_generic_612102,6.1.2.1.02,Rendimentos de Aplicações Financeiras,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_financial,l10n_br_coa.account_tag_result"
+coa_generic_611201,6.1.1.2.01,Simples Nacional s/ Faturamento,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611202,6.1.1.2.02,ISS Substituição Tributária s/ Prestação de Serviços,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611203,6.1.1.2.03,ICMS s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611204,6.1.1.2.04,ISS s/ Prestação de Serviços,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611205,6.1.1.2.05,COFINS s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611206,6.1.1.2.06,PIS s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611207,6.1.1.2.07,ICMS ST s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611208,6.1.1.2.08,IPI s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611209,6.1.1.2.09,CSLL s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611210,6.1.1.2.10,IRPJ s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611211,6.1.1.2.11,II s/ Vendas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611221,6.1.1.2.21,(-)  Simples Nacional Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611222,6.1.1.2.22,(-)  ISS Substituição Tributária Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611223,6.1.1.2.23,(-)  ICMS Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611224,6.1.1.2.24,(-)  ISS Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611225,6.1.1.2.25,(-)  COFINS Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611226,6.1.1.2.26,(-)  PIS Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611227,6.1.1.2.27,(-)  ICMS ST Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611228,6.1.1.2.28,(-)  IPI Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611229,6.1.1.2.29,(-)  CSLL Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611230,6.1.1.2.30,(-)  IRPJ Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611231,6.1.1.2.31,(-)  II Devolução,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611301,6.1.1.3.01,(-) Devolução de Vendas de Mercadorias,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611302,6.1.1.3.02,(-) Devolução de Vendas de Mercadorias com Substituição Tributária,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611303,6.1.1.3.03,(-) Devolução de Vendas de Mercadorias para o Exterior,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611304,6.1.1.3.04,(-) Devolução de Vendas de Produtos de Fabricação Própria,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611305,6.1.1.3.05,(-) Devolução de Vendas de Produtos de Fabricação Própria com Substituição Tributária,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611306,6.1.1.3.06,(-) Devolução de Vendas de Produtos de Fabricação Própria para o Exterior,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611307,6.1.1.3.07,(-) Anulação de Vendas de Serviços Prestados,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611308,6.1.1.3.08,(-) Anulação Vendas de Serviços Prestados com Substituição Tributária,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_611309,6.1.1.3.09,(-) Anulação Vendas de Serviços Prestados para o Exterior,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+coa_generic_612101,6.1.2.1.01,Juros Ativos,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_transfer"
+coa_generic_612102,6.1.2.1.02,Rendimentos de Aplicações Financeiras,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_revenue_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_transfer"
 coa_generic_613101,6.1.3.1.01,Recuperação de Despesas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
-coa_generic_616101,6.1.6.1.01,Ganhos de Capital,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
+coa_generic_616101,6.1.6.1.01,Ganhos de Capital,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_disposal_result"
 coa_generic_616102,6.1.6.1.02,Outras Receitas,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
 coa_generic_616201,6.1.6.2.01,Venda de Bens do Ativo Imobilizado,,income_other,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
-coa_generic_711101,7.1.1.1.01,Ativo,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_711102,7.1.1.1.02,(-) Passivo,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
-coa_generic_711201,7.1.1.2.01,Ativo,,liability_non_current,0,l10n_br_coa_generic_template,l10n_br_coa.account_tag_compensation_assets
+coa_generic_711101,7.1.1.1.01,Ativo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_711102,7.1.1.1.02,(-) Passivo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"
+coa_generic_711201,7.1.1.2.01,Ativo,,liability_non_current,0,l10n_br_coa_generic_template,"l10n_br_coa.account_tag_compensation_assets,l10n_br_coa.account_tag_cash_flow_non_cash"

--- a/l10n_br_coa_simple/data/account.account.template.csv
+++ b/l10n_br_coa_simple/data/account.account.template.csv
@@ -1,229 +1,229 @@
 id,code,name,note,account_type,reconcile,chart_template_id:id,tag_ids:id
-account_template_1110101,1.1.1.01.01,Caixa,,asset_cash,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_cash
-account_template_1110102,1.1.1.01.02,Fundo Fixo de Caixa,,asset_cash,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_cash
-account_template_1110201,1.1.1.02.01,Bancos Conta Movimento,,asset_cash,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_cash
-account_template_1110301,1.1.1.03.01,Aplicação Financeira de Liquidez Imediata,,asset_cash,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_cash
-account_template_1120101,1.1.2.01.01,Contas a Receber,,asset_receivable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120102,1.1.2.01.02,PECLD,,asset_receivable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120201,1.1.2.02.01,Adiantamento Quinzenal,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120202,1.1.2.02.02,Empréstimos a colaboradores,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120203,1.1.2.02.03,Antecipação de Salários,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120204,1.1.2.02.04,Antecipação de Férias,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120205,1.1.2.02.05,Antecipação de 13º Salário,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120301,1.1.2.03.01,Adiantamentos a Fornecedores,,asset_receivable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120401,1.1.2.04.01,IRRF,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120402,1.1.2.04.02,CSLL Retida na Fonte,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120403,1.1.2.04.03,PIS Retido na fonte,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120404,1.1.2.04.04,COFINS Retida na Fonte,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120405,1.1.2.04.05,INSS Retido na Fonte,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120501,1.1.2.05.01,IPI a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120502,1.1.2.05.02,ICMS a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120503,1.1.2.05.03,PIS a Recuperar - Crédito Básico,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120504,1.1.2.05.04,PIS a Recuperar - Crédito Presumido,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120505,1.1.2.05.05,COFINS a Recuperar - Crédito Básico,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120506,1.1.2.05.06,COFINS a Recuperar - Crédito Presumido,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120507,1.1.2.05.07,CIDE a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120508,1.1.2.05.08,Outros Impostos e Contribuições a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120509,1.1.2.05.09,Saldo Negativo - IRPJ,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120510,1.1.2.05.10,Saldo Negativo - CSLL,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120511,1.1.2.05.11,IBS a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120512,1.1.2.05.12,CBS a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120513,1.1.2.05.13,IS a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120601,1.1.2.06.01,IRPJ Estimativa,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120602,1.1.2.06.02,CSLL Estimativa,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120603,1.1.2.06.03,COFINS a Compensar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120604,1.1.2.06.04,PIS/PASEP a Compensar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120605,1.1.2.06.05,IPI a Compensar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1120606,1.1.2.06.06,INSS a compensar,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_receivable
-account_template_1130101,1.1.3.01.01,Mercadorias para Revenda,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_stock
-account_template_1130102,1.1.3.01.02,(-) Perda por Ajuste ao Valor Realizável Líquido - Estoque Mercadorias,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_stock
-account_template_1130201,1.1.3.02.01,Insumos (materiais diretos),,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_stock
-account_template_1130202,1.1.3.02.02,Outros Materiais,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_stock
-account_template_1130203,1.1.3.02.03,Produtos em Elaboração,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_stock
-account_template_1130204,1.1.3.02.04,Produtos Acabados,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_stock
-account_template_1130205,1.1.3.02.05,(-) Perda por Ajuste ao Valor Realizável Líquido - Estoque Produtos,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_stock
-account_template_1130301,1.1.3.03.01,Materiais para Consumo,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_stock
-account_template_1130302,1.1.3.03.02,Materiais para Reposição,,asset_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_stock
-account_template_1140101,1.1.4.01.01,Aluguéis e Arredamentos Pagos Antecipadamente,,liability_payable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_other_credits
-account_template_1140102,1.1.4.01.02,Prêmios de Seguros a Apropriar,,liability_payable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_other_credits
-account_template_1160199,1.1.6.01.99,Outras Despesas Antecipadas,,liability_payable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_assets_other_credits
-account_template_1210101,1.2.1.01.01,Clientes - Longo Prazo,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_assets_receivable
-account_template_1210102,1.2.1.01.02,PCLD Longo Prazo,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_assets_receivable
-account_template_1210103,1.2.1.01.03,Juros a apropriar Clientes LP,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_assets_receivable
-account_template_1210104,1.2.1.01.04,Empréstimos de LP,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_assets_receivable
-account_template_1210105,1.2.1.01.05,Juros a apropriar Empréstimos LP,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_assets_receivable
-account_template_1210201,1.2.1.02.01,IRPJ Diferido,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_assets_receivable
-account_template_1210202,1.2.1.02.02,CSLL Diferido,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_assets_receivable
-account_template_1220101,1.2.2.01.01,Investimentos em Controladas,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_investments
-account_template_1220102,1.2.2.01.02,Ágio pago pela mais valia,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_investments
-account_template_1220103,1.2.2.01.03,Ágio pago por Goodwill,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_investments
-account_template_1220104,1.2.2.01.04,Investimentos em Coligadas,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_investments
-account_template_1220105,1.2.2.01.05,Investimentos em Joint Ventures,,asset_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_investments
-account_template_1230110,1.2.3.01.10,Terrenos,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230111,1.2.3.01.11,Impairment Terrenos,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230120,1.2.3.01.20,Edifícios e Construções,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230121,1.2.3.01.21,Impairment Edifícios e Construções,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230130,1.2.3.01.30,Benfeitorias em Imóveis de Terceiros,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230131,1.2.3.01.31,Impairment Benfeitorias em Imóveis de Terceiros,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230140,1.2.3.01.40,"Máquinas, Equipamentos e Instalações Industriais",,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230141,1.2.3.01.41,"Impairment Máquinas, Equipamentos e Instalações Industriais",,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230150,1.2.3.01.50,"Móveis, Utensílios e Instalações Comerciais",,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230151,1.2.3.01.51,"Impairment Móveis, Utensílios e Instalações Comerciais",,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230160,1.2.3.01.60,Veículos,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230161,1.2.3.01.61,Impairment Veículos,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230162,1.2.3.01.62,Terrenos para Investimento - Custo,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230170,1.2.3.01.70,Edifícios para Investimento - Custo,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230171,1.2.3.01.71,Edifícios para Investimento - Depreciação,,expense_depreciation,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets
-account_template_1230220,1.2.3.02.20,Depreciação Acumulada - Edifícios e Construções,,expense_depreciation,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-account_template_1230230,1.2.3.02.30,Depreciação Acumulada - Benfeitorias em Imóveis de Terceiros,,expense_depreciation,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_fixed_assets_depreciation
-account_template_1240110,1.2.4.01.10,Softwares,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets
-account_template_1240111,1.2.4.01.11,Impairment - Softwares,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets
-account_template_1240120,1.2.4.01.20,Marcas,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets
-account_template_1240121,1.2.4.01.21,Impairment - Marcas,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets
-account_template_1240130,1.2.4.01.30,Patentes e Segredos Industriais,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets
-account_template_1240131,1.2.4.01.31,Impairment - Patentes e Segredos Industriais,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets
-account_template_1240140,1.2.4.01.40,Goodwill,,asset_fixed,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets
-account_template_1240210,1.2.4.02.10,Amortização Acumulada - Softwares,,expense_depreciation,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets_amortization
-account_template_1240220,1.2.4.02.20,Amortização Acumulada - Marcas,,expense_depreciation,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets_amortization
-account_template_1240230,1.2.4.02.30,Amortização Acumulada - Patentes e Segredos Industriais,,expense_depreciation,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_intangible_assets_amortization
-account_template_2110101,2.1.1.01.01,Salários e Remunerações a Pagar,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110102,2.1.1.01.02,Participações no Resultado a Pagar,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110103,2.1.1.01.03,INSS a Recolher,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110104,2.1.1.01.04,FGTS a Recolher,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110105,2.1.1.01.05,INSS desoneração da folha,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110106,2.1.1.01.06,Férias,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110107,2.1.1.01.07,13º Salário,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110108,2.1.1.01.08,INSS - Férias,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110109,2.1.1.01.09,FGTS - Férias,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110110,2.1.1.01.10,INSS - 13º Salário,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2110111,2.1.1.01.11,FGTS - 13º Salário,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_labor
-account_template_2120101,2.1.2.01.01,Fornecedores Nacionais,,liability_payable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_suppliers
-account_template_2120102,2.1.2.01.02,Fornecedores Exterior,,liability_payable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_suppliers
-account_template_2120201,2.1.2.02.01,Aluguéis e Arrendamentos a Pagar,,liability_payable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_payable
-account_template_2120202,2.1.2.02.02,Adiantamento de Clientes,,asset_receivable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_payable
-account_template_2120203,2.1.2.02.03,Outras Contas a Pagar,,liability_payable,1,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_payable
-account_template_2130101,2.1.3.01.01,Duplicatas Descontadas,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_payable
-account_template_2130102,2.1.3.01.02,Empréstimos e Financiamentos,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_payable
-account_template_2140101,2.1.4.01.01,IRRF,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140102,2.1.4.01.02,CSRF,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140103,2.1.4.01.03,ISS retido na Fonte,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140104,2.1.4.01.04,INSS retido na Fonte,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140105,2.1.4.01.05,IBS Retido na Fonte,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140106,2.1.4.01.06,CBS Retido na Fonte,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140201,2.1.4.02.01,IRPJ,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140202,2.1.4.02.02,CSLL,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140203,2.1.4.02.03,PIS,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140204,2.1.4.02.04,COFINS,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140205,2.1.4.02.05,IPI,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140206,2.1.4.02.06,ICMS,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140207,2.1.4.02.07,IOF,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140208,2.1.4.02.08,ISS,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140209,2.1.4.02.09,Tributos Municipais,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140210,2.1.4.02.10,Simples Nacional,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140211,2.1.4.02.11,IBS,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140212,2.1.4.02.12,CBS,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140213,2.1.4.02.13,IS,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140301,2.1.4.03.01,Tributos Federais,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2140302,2.1.4.03.02,Tributos Estaduais e Municipais,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2150101,2.1.5.01.01,IRPJ,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2150102,2.1.5.01.02,CSLL,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_fiscal
-account_template_2160101,2.1.6.01.01,Lucros a Pagar,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_payable
-account_template_2160102,2.1.6.01.02,Mútuo com Partes Relacionadas,,liability_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_current_liabilities_payable
-account_template_2210101,2.2.1.01.01,Fornecedores Nacionais,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2210102,2.2.1.01.02,Fornecedores Exterior,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2210103,2.2.1.01.03,Juros a apropriar Obrigações LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2210201,2.2.1.02.01,Empréstimos e Financiamentos LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2210202,2.2.1.02.02,Duplicatas Descontadas LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2210203,2.2.1.02.03,Juros a apropriar Empréstimos LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2220101,2.2.2.01.01,Tributos Federais LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2220102,2.2.2.01.02,Tributos Estaduais e Municipais LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2220201,2.2.2.02.01,IRPJ Diferido,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2220202,2.2.2.02.02,CSLL Diferido,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities
-account_template_2230101,2.2.3.01.01,Empréstimos de Sócios,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities_loan
-account_template_2230102,2.2.3.01.02,Mútuos com Partes Relacionadas,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities_loan
-account_template_2230103,2.2.3.01.03,Juros a Apropriar Partes Relacionadas,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_non_current_liabilities_loan
-account_template_2310101,2.3.1.01.01,Capital Social Subscrito,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_equity_capital
-account_template_2810201,2.8.1.02.01,Capital Social a Integralizar,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_equity_capital
-account_template_2820101,2.8.2.01.01,Adiantamento para Futuro Aumento de Capital,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_equity_capital
-account_template_2830101,2.8.3.01.01,Lucros a Distribuir,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_equity_profit_reserve
-account_template_2880101,2.8.8.01.01,Lucros Acumulados,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_equity_accumulated_profits
-account_template_2880201,2.8.8.02.01,Prejuízos Acumulados,,liability_non_current,0,l10n_br_coa_simple_chart_template,l10n_br_coa.account_tag_equity_accumulated_losses
+account_template_1110101,1.1.1.01.01,Caixa,,asset_cash,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_cash,l10n_br_coa.account_tag_cash_and_equivalents"
+account_template_1110102,1.1.1.01.02,Fundo Fixo de Caixa,,asset_cash,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_cash,l10n_br_coa.account_tag_cash_and_equivalents"
+account_template_1110201,1.1.1.02.01,Bancos Conta Movimento,,asset_cash,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_cash,l10n_br_coa.account_tag_cash_and_equivalents"
+account_template_1110301,1.1.1.03.01,Aplicação Financeira de Liquidez Imediata,,asset_cash,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_cash,l10n_br_coa.account_tag_cash_and_equivalents"
+account_template_1120101,1.1.2.01.01,Contas a Receber,,asset_receivable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120102,1.1.2.01.02,PECLD,,asset_receivable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120201,1.1.2.02.01,Adiantamento Quinzenal,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120202,1.1.2.02.02,Empréstimos a colaboradores,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_1120203,1.1.2.02.03,Antecipação de Salários,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120204,1.1.2.02.04,Antecipação de Férias,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120205,1.1.2.02.05,Antecipação de 13º Salário,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120301,1.1.2.03.01,Adiantamentos a Fornecedores,,asset_receivable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120401,1.1.2.04.01,IRRF,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120402,1.1.2.04.02,CSLL Retida na Fonte,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120403,1.1.2.04.03,PIS Retido na fonte,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120404,1.1.2.04.04,COFINS Retida na Fonte,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120405,1.1.2.04.05,INSS Retido na Fonte,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120501,1.1.2.05.01,IPI a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120502,1.1.2.05.02,ICMS a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120503,1.1.2.05.03,PIS a Recuperar - Crédito Básico,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120504,1.1.2.05.04,PIS a Recuperar - Crédito Presumido,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120505,1.1.2.05.05,COFINS a Recuperar - Crédito Básico,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120506,1.1.2.05.06,COFINS a Recuperar - Crédito Presumido,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120507,1.1.2.05.07,CIDE a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120508,1.1.2.05.08,Outros Impostos e Contribuições a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120509,1.1.2.05.09,Saldo Negativo - IRPJ,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120510,1.1.2.05.10,Saldo Negativo - CSLL,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120511,1.1.2.05.11,IBS a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120512,1.1.2.05.12,CBS a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120513,1.1.2.05.13,IS a Recuperar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120601,1.1.2.06.01,IRPJ Estimativa,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120602,1.1.2.06.02,CSLL Estimativa,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120603,1.1.2.06.03,COFINS a Compensar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120604,1.1.2.06.04,PIS/PASEP a Compensar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120605,1.1.2.06.05,IPI a Compensar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1120606,1.1.2.06.06,INSS a compensar,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1130101,1.1.3.01.01,Mercadorias para Revenda,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1130102,1.1.3.01.02,(-) Perda por Ajuste ao Valor Realizável Líquido - Estoque Mercadorias,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1130201,1.1.3.02.01,Insumos (materiais diretos),,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1130202,1.1.3.02.02,Outros Materiais,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1130203,1.1.3.02.03,Produtos em Elaboração,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1130204,1.1.3.02.04,Produtos Acabados,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1130205,1.1.3.02.05,(-) Perda por Ajuste ao Valor Realizável Líquido - Estoque Produtos,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1130301,1.1.3.03.01,Materiais para Consumo,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1130302,1.1.3.03.02,Materiais para Reposição,,asset_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_stock,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1140101,1.1.4.01.01,Aluguéis e Arredamentos Pagos Antecipadamente,,liability_payable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1140102,1.1.4.01.02,Prêmios de Seguros a Apropriar,,liability_payable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1160199,1.1.6.01.99,Outras Despesas Antecipadas,,liability_payable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_assets_other_credits,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1210101,1.2.1.01.01,Clientes - Longo Prazo,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1210102,1.2.1.01.02,PCLD Longo Prazo,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1210103,1.2.1.01.03,Juros a apropriar Clientes LP,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1210104,1.2.1.01.04,Empréstimos de LP,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_1210105,1.2.1.01.05,Juros a apropriar Empréstimos LP,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_1210201,1.2.1.02.01,IRPJ Diferido,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1210202,1.2.1.02.02,CSLL Diferido,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_assets_receivable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_1220101,1.2.2.01.01,Investimentos em Controladas,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_investments,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1220102,1.2.2.01.02,Ágio pago pela mais valia,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_investments,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1220103,1.2.2.01.03,Ágio pago por Goodwill,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_investments,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1220104,1.2.2.01.04,Investimentos em Coligadas,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_investments,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1220105,1.2.2.01.05,Investimentos em Joint Ventures,,asset_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_investments,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230110,1.2.3.01.10,Terrenos,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230111,1.2.3.01.11,Impairment Terrenos,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230120,1.2.3.01.20,Edifícios e Construções,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230121,1.2.3.01.21,Impairment Edifícios e Construções,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230130,1.2.3.01.30,Benfeitorias em Imóveis de Terceiros,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230131,1.2.3.01.31,Impairment Benfeitorias em Imóveis de Terceiros,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230140,1.2.3.01.40,"Máquinas, Equipamentos e Instalações Industriais",,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230141,1.2.3.01.41,"Impairment Máquinas, Equipamentos e Instalações Industriais",,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230150,1.2.3.01.50,"Móveis, Utensílios e Instalações Comerciais",,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230151,1.2.3.01.51,"Impairment Móveis, Utensílios e Instalações Comerciais",,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230160,1.2.3.01.60,Veículos,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230161,1.2.3.01.61,Impairment Veículos,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230162,1.2.3.01.62,Terrenos para Investimento - Custo,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230170,1.2.3.01.70,Edifícios para Investimento - Custo,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230171,1.2.3.01.71,Edifícios para Investimento - Depreciação,,expense_depreciation,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1230220,1.2.3.02.20,Depreciação Acumulada - Edifícios e Construções,,expense_depreciation,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+account_template_1230230,1.2.3.02.30,Depreciação Acumulada - Benfeitorias em Imóveis de Terceiros,,expense_depreciation,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_fixed_assets_depreciation,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+account_template_1240110,1.2.4.01.10,Softwares,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1240111,1.2.4.01.11,Impairment - Softwares,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1240120,1.2.4.01.20,Marcas,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1240121,1.2.4.01.21,Impairment - Marcas,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1240130,1.2.4.01.30,Patentes e Segredos Industriais,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1240131,1.2.4.01.31,Impairment - Patentes e Segredos Industriais,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1240140,1.2.4.01.40,Goodwill,,asset_fixed,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets,l10n_br_coa.account_tag_cash_flow_investing"
+account_template_1240210,1.2.4.02.10,Amortização Acumulada - Softwares,,expense_depreciation,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets_amortization,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+account_template_1240220,1.2.4.02.20,Amortização Acumulada - Marcas,,expense_depreciation,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets_amortization,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+account_template_1240230,1.2.4.02.30,Amortização Acumulada - Patentes e Segredos Industriais,,expense_depreciation,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_intangible_assets_amortization,l10n_br_coa.account_tag_cash_flow_result_adjustment"
+account_template_2110101,2.1.1.01.01,Salários e Remunerações a Pagar,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110102,2.1.1.01.02,Participações no Resultado a Pagar,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110103,2.1.1.01.03,INSS a Recolher,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110104,2.1.1.01.04,FGTS a Recolher,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110105,2.1.1.01.05,INSS desoneração da folha,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110106,2.1.1.01.06,Férias,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110107,2.1.1.01.07,13º Salário,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110108,2.1.1.01.08,INSS - Férias,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110109,2.1.1.01.09,FGTS - Férias,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110110,2.1.1.01.10,INSS - 13º Salário,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2110111,2.1.1.01.11,FGTS - 13º Salário,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_labor,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2120101,2.1.2.01.01,Fornecedores Nacionais,,liability_payable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_suppliers,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2120102,2.1.2.01.02,Fornecedores Exterior,,liability_payable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_suppliers,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2120201,2.1.2.02.01,Aluguéis e Arrendamentos a Pagar,,liability_payable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2120202,2.1.2.02.02,Adiantamento de Clientes,,asset_receivable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2120203,2.1.2.02.03,Outras Contas a Pagar,,liability_payable,1,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2130101,2.1.3.01.01,Duplicatas Descontadas,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2130102,2.1.3.01.02,Empréstimos e Financiamentos,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2140101,2.1.4.01.01,IRRF,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140102,2.1.4.01.02,CSRF,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140103,2.1.4.01.03,ISS retido na Fonte,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140104,2.1.4.01.04,INSS retido na Fonte,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140105,2.1.4.01.05,IBS Retido na Fonte,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140106,2.1.4.01.06,CBS Retido na Fonte,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140201,2.1.4.02.01,IRPJ,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140202,2.1.4.02.02,CSLL,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140203,2.1.4.02.03,PIS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140204,2.1.4.02.04,COFINS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140205,2.1.4.02.05,IPI,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140206,2.1.4.02.06,ICMS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140207,2.1.4.02.07,IOF,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140208,2.1.4.02.08,ISS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140209,2.1.4.02.09,Tributos Municipais,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140210,2.1.4.02.10,Simples Nacional,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140211,2.1.4.02.11,IBS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140212,2.1.4.02.12,CBS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140213,2.1.4.02.13,IS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140301,2.1.4.03.01,Tributos Federais,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2140302,2.1.4.03.02,Tributos Estaduais e Municipais,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2150101,2.1.5.01.01,IRPJ,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2150102,2.1.5.01.02,CSLL,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_fiscal,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2160101,2.1.6.01.01,Lucros a Pagar,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2160102,2.1.6.01.02,Mútuo com Partes Relacionadas,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_current_liabilities_payable,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2210101,2.2.1.01.01,Fornecedores Nacionais,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2210102,2.2.1.01.02,Fornecedores Exterior,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2210103,2.2.1.01.03,Juros a apropriar Obrigações LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2210201,2.2.1.02.01,Empréstimos e Financiamentos LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2210202,2.2.1.02.02,Duplicatas Descontadas LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2210203,2.2.1.02.03,Juros a apropriar Empréstimos LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2220101,2.2.2.01.01,Tributos Federais LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2220102,2.2.2.01.02,Tributos Estaduais e Municipais LP,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2220201,2.2.2.02.01,IRPJ Diferido,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2220202,2.2.2.02.02,CSLL Diferido,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities,l10n_br_coa.account_tag_cash_flow_operating"
+account_template_2230101,2.2.3.01.01,Empréstimos de Sócios,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities_loan,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2230102,2.2.3.01.02,Mútuos com Partes Relacionadas,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities_loan,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2230103,2.2.3.01.03,Juros a Apropriar Partes Relacionadas,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_non_current_liabilities_loan,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2310101,2.3.1.01.01,Capital Social Subscrito,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_equity_capital,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2810201,2.8.1.02.01,Capital Social a Integralizar,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_equity_capital,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2820101,2.8.2.01.01,Adiantamento para Futuro Aumento de Capital,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_equity_capital,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2830101,2.8.3.01.01,Lucros a Distribuir,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_equity_profit_reserve,l10n_br_coa.account_tag_cash_flow_financing"
+account_template_2880101,2.8.8.01.01,Lucros Acumulados,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_equity_accumulated_profits,l10n_br_coa.account_tag_cash_flow_non_cash"
+account_template_2880201,2.8.8.02.01,Prejuízos Acumulados,,liability_non_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_equity_accumulated_losses,l10n_br_coa.account_tag_cash_flow_non_cash"
 account_template_3110101,3.1.1.01.01,Serviços Prestados,,income,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue,l10n_br_coa.account_tag_result"
 account_template_3110102,3.1.1.01.02,Mercadorias Vendidas,,income,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue,l10n_br_coa.account_tag_result"
 account_template_3110103,3.1.1.01.03,Produtos Vendidos,,income,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue,l10n_br_coa.account_tag_result"
-account_template_3120101,3.1.2.01.01,PIS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120102,3.1.2.01.02,COFINS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120103,3.1.2.01.03,ISS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120104,3.1.2.01.04,ICMS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120105,3.1.2.01.05,SIMPLES NACIONAL,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120106,3.1.2.01.06,IBS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120107,3.1.2.01.07,CBS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120108,3.1.2.01.08,IS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120201,3.1.2.02.01,DESCONTOS E ABATIMENTOS,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120202,3.1.2.02.02,DEVOLUÇÕES,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3120203,3.1.2.02.03,JUROS DE AVP,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result"
-account_template_3210101,3.2.1.01.01,Custos dos Produtos Vendidos,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result"
-account_template_3210102,3.2.1.01.02,Custos das Mercadorias Vendidas,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result"
-account_template_3210103,3.2.1.01.03,Custos dos Serviços Prestados,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result"
-account_template_3310101,3.3.1.01.01,Salários,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310102,3.3.1.01.02,Gratificações,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310103,3.3.1.01.03,Férias,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310104,3.3.1.01.04,13º Salário,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310105,3.3.1.01.05,INSS,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310106,3.3.1.01.06,FGTS,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310107,3.3.1.01.07,Vale Refeição/Refeitório,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310108,3.3.1.01.08,Vale Transporte,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310109,3.3.1.01.09,Assistência Médica,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310110,3.3.1.01.10,Seguro de Vida,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310111,3.3.1.01.11,Treinamento,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310201,3.3.1.02.01,Comissões sobre Vendas,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310202,3.3.1.02.02,Propaganda e publicidade,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3310203,3.3.1.02.03,Brindes e material promocional,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result"
-account_template_3320101,3.3.2.01.01,Salários,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320102,3.3.2.01.02,Gratificações,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320103,3.3.2.01.03,Férias,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320104,3.3.2.01.04,13º Salário,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320105,3.3.2.01.05,INSS,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320106,3.3.2.01.06,FGTS,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320107,3.3.2.01.07,Vale Refeiçãoo/Refeitório,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320108,3.3.2.01.08,Vale Transporte,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320109,3.3.2.01.09,Assistência Médica,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320110,3.3.2.01.10,Seguro de Vida,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320111,3.3.2.01.11,Treinamento,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320112,3.3.2.01.12,Pro Labore,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320201,3.3.2.02.01,Aluguéis e Arrendamentos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320202,3.3.2.02.02,Condomínios e Estacionamentos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320203,3.3.2.02.03,Despesas com Veículos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320204,3.3.2.02.04,Depreciação,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320205,3.3.2.02.05,Amortização,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320206,3.3.2.02.06,Serviços Profissionais Contratados,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320207,3.3.2.02.07,Energia,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320208,3.3.2.02.08,Água e Esgoto,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320209,3.3.2.02.09,Telefone e Internet,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320210,3.3.2.02.10,Correios e Malotes,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320211,3.3.2.02.11,Seguros,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320212,3.3.2.02.12,Multas,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320213,3.3.2.02.13,Bens de Pequeno Valor,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320214,3.3.2.02.14,Material de Escritório,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320301,3.3.2.03.01,Taxas e Tributos Municipais,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320302,3.3.2.03.02,PIS s/ Outras Receitas,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
-account_template_3320303,3.3.2.03.03,COFINS s/ Outras Receitas,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result"
+account_template_3120101,3.1.2.01.01,PIS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120102,3.1.2.01.02,COFINS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120103,3.1.2.01.03,ISS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120104,3.1.2.01.04,ICMS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120105,3.1.2.01.05,SIMPLES NACIONAL,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120106,3.1.2.01.06,IBS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120107,3.1.2.01.07,CBS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120108,3.1.2.01.08,IS,,liability_current,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120201,3.1.2.02.01,DESCONTOS E ABATIMENTOS,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120202,3.1.2.02.02,DEVOLUÇÕES,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3120203,3.1.2.02.03,JUROS DE AVP,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_revenue_deduction,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3210101,3.2.1.01.01,Custos dos Produtos Vendidos,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3210102,3.2.1.01.02,Custos das Mercadorias Vendidas,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3210103,3.2.1.01.03,Custos dos Serviços Prestados,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_direct_costs,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3310101,3.3.1.01.01,Salários,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3310102,3.3.1.01.02,Gratificações,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3310103,3.3.1.01.03,Férias,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3310104,3.3.1.01.04,13º Salário,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3310105,3.3.1.01.05,INSS,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3310106,3.3.1.01.06,FGTS,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3310107,3.3.1.01.07,Vale Refeição/Refeitório,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3310108,3.3.1.01.08,Vale Transporte,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3310109,3.3.1.01.09,Assistência Médica,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3310110,3.3.1.01.10,Seguro de Vida,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3310111,3.3.1.01.11,Treinamento,,expense_direct_cost,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3310201,3.3.1.02.01,Comissões sobre Vendas,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3310202,3.3.1.02.02,Propaganda e publicidade,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3310203,3.3.1.02.03,Brindes e material promocional,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_sale_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320101,3.3.2.01.01,Salários,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320102,3.3.2.01.02,Gratificações,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320103,3.3.2.01.03,Férias,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320104,3.3.2.01.04,13º Salário,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320105,3.3.2.01.05,INSS,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320106,3.3.2.01.06,FGTS,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320107,3.3.2.01.07,Vale Refeiçãoo/Refeitório,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320108,3.3.2.01.08,Vale Transporte,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320109,3.3.2.01.09,Assistência Médica,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320110,3.3.2.01.10,Seguro de Vida,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320111,3.3.2.01.11,Treinamento,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320112,3.3.2.01.12,Pro Labore,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_personnel"
+account_template_3320201,3.3.2.02.01,Aluguéis e Arrendamentos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3320202,3.3.2.02.02,Condomínios e Estacionamentos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320203,3.3.2.02.03,Despesas com Veículos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320204,3.3.2.02.04,Depreciação,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs,l10n_br_coa.account_tag_depreciation_expense"
+account_template_3320205,3.3.2.02.05,Amortização,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs,l10n_br_coa.account_tag_depreciation_expense"
+account_template_3320206,3.3.2.02.06,Serviços Profissionais Contratados,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3320207,3.3.2.02.07,Energia,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320208,3.3.2.02.08,Água e Esgoto,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320209,3.3.2.02.09,Telefone e Internet,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320210,3.3.2.02.10,Correios e Malotes,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320211,3.3.2.02.11,Seguros,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320212,3.3.2.02.12,Multas,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320213,3.3.2.02.13,Bens de Pequeno Valor,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320214,3.3.2.02.14,Material de Escritório,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_inputs"
+account_template_3320301,3.3.2.03.01,Taxas e Tributos Municipais,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3320302,3.3.2.03.02,PIS s/ Outras Receitas,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3320303,3.3.2.03.03,COFINS s/ Outras Receitas,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_admin_expenses,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
 account_template_3390101,3.3.9.01.01,Receita na Venda de Imobilizado,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
 account_template_3390102,3.3.9.01.02,Custo do Imobilizado Baixado,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
 account_template_3390201,3.3.9.02.01,PECLD,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
 account_template_3390202,3.3.9.02.02,Perda de recuperabilidade (Impairment),,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
-account_template_3390301,3.3.9.03.01,Resultado Positivo de Equivalência Patrimonial,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
-account_template_3390302,3.3.9.03.02,Resultado Negativo de Equivalência Patrimonial,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result"
-account_template_3410101,3.4.1.01.01,Juros Passivos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-account_template_3410102,3.4.1.01.02,Despesas Bancárias,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-account_template_3410103,3.4.1.01.03,IOF,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-account_template_3410104,3.4.1.01.04,Descontos Concedidos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-account_template_3410105,3.4.1.01.05,Variação Cambial Passiva,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-account_template_3410201,3.4.1.02.01,Rendimentos de Aplicação Financeira,,income_other,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-account_template_3410202,3.4.1.02.02,Juros Ativos,,income_other,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-account_template_3410203,3.4.1.02.03,Descontos Obtidos,,income_other,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-account_template_3410204,3.4.1.02.04,Variação Cambial Ativa,,income_other,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result"
-account_template_3810101,3.8.1.01.01,IRPJ Corrente,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expense_irpj,l10n_br_coa.account_tag_result"
-account_template_3810102,3.8.1.01.02,CSLL Corrente,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expense_csll,l10n_br_coa.account_tag_result"
-account_template_3810103,3.8.1.01.03,IRPJ Diferido,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expense_irpj,l10n_br_coa.account_tag_result"
-account_template_3810104,3.8.1.01.04,CSLL Diferido,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expense_csll,l10n_br_coa.account_tag_result"
+account_template_3390301,3.3.9.03.01,Resultado Positivo de Equivalência Patrimonial,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_equity_method_result"
+account_template_3390302,3.3.9.03.02,Resultado Negativo de Equivalência Patrimonial,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_other_operating_results,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_equity_method_result"
+account_template_3410101,3.4.1.01.01,Juros Passivos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3410102,3.4.1.01.02,Despesas Bancárias,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3410103,3.4.1.01.03,IOF,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3410104,3.4.1.01.04,Descontos Concedidos,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3410105,3.4.1.01.05,Variação Cambial Passiva,,expense,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3410201,3.4.1.02.01,Rendimentos de Aplicação Financeira,,income_other,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3410202,3.4.1.02.02,Juros Ativos,,income_other,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3410203,3.4.1.02.03,Descontos Obtidos,,income_other,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3410204,3.4.1.02.04,Variação Cambial Ativa,,income_other,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expenses_financial,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_third_party_capital"
+account_template_3810101,3.8.1.01.01,IRPJ Corrente,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expense_irpj,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3810102,3.8.1.01.02,CSLL Corrente,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expense_csll,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3810103,3.8.1.01.03,IRPJ Diferido,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expense_irpj,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"
+account_template_3810104,3.8.1.01.04,CSLL Diferido,,equity,0,l10n_br_coa_simple_chart_template,"l10n_br_coa.account_tag_expense_csll,l10n_br_coa.account_tag_result,l10n_br_coa.account_tag_dva_taxes"

--- a/l10n_br_mis_report/README.rst
+++ b/l10n_br_mis_report/README.rst
@@ -28,46 +28,13 @@ Relatórios contábeis brasileiros: Balanço Patrimonial e DRE
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-Este módulo implementa **Modelos de Relatórios Contábeis Brasileiros**,
-como o **Demonstrativo de Resultados do Exercício (DRE)** e o **Balanço
-Patrimonial (BP)**, baseados na norma **ITG 1000**. Ele permite que
-pequenas empresas e microentidades gerem relatórios contábeis de acordo
-com os padrões brasileiros, com a flexibilidade de personalizar os
-modelos conforme o plano de contas de cada empresa.
+Balanço Patrimonial e Demonstração do Resultado do Exercício brasileiros
+para o mis_builder, com os relatórios já montados e os períodos em que a
+legislação brasileira manda apurar e demonstrar.
 
-**Nota:** Embora esses modelos sejam **inspirados no ITG 1000**, eles
-**não correspondem exatamente ao modelo proposto pela norma**. Além
-disso, pode haver **diferenças** em relação às versões mais recentes do
-ITG 1000.
-
-Para mais informações, consulte as `Normas Simplificadas para PMEs no
-site do
-CFC <https://cfc.org.br/tecnica/normas-brasileiras-de-contabilidade/normas-simplificadas-para-pmes/>`__.
-
-**Observação:** Esses modelos são um **ponto de partida** e precisam ser
-**ajustados** de acordo com o plano de contas da sua empresa. Por
-padrão, eles estão configurados com os prefixos das contas contábeis da
-**localização brasileira da OCA**. Para saber mais sobre como configurar
-corretamente esses modelos, consulte a **seção de configuração**.
-
-Balanço Patrimonial (BP)
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Abaixo está um exemplo visual de um **Balanço Patrimonial** inspirado no
-ITG 1000:
-
-|Balanço Patrimonial|
-
-Demonstrativo de Resultados do Exercício (DRE)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Abaixo está um exemplo visual de um **DRE** (Demonstrativo de Resultados
-do Exercício) inspirado no ITG 1000:
-
-|DRE|
-
-.. |Balanço Patrimonial| image:: https://raw.githubusercontent.com/OCA/l10n-brazil/16.0/l10n_br_mis_report/static/description/bp.png
-.. |DRE| image:: https://raw.githubusercontent.com/OCA/l10n-brazil/16.0/l10n_br_mis_report/static/description/dre.png
+O Balanço segue a ordem do art. 178 da Lei 6.404/76 e a DRE a do art.
+187. As contas são selecionadas pela classificação contábil, então os
+mesmos relatórios servem qualquer plano de contas.
 
 **Table of contents**
 
@@ -80,68 +47,84 @@ Installation
 Este módulo tem como dependência o módulo ``mis_builder``, que pode ser
 encontrado nos seguintes locais:
 
--  `Odoo Community Association (OCA)
-   Shop <https://odoo-community.org/shop>`__
--  `Repositório no GitHub <https://github.com/OCA/mis-builder>`__
+- `Odoo Community Association (OCA)
+  Shop <https://odoo-community.org/shop>`__
+- `Repositório no GitHub <https://github.com/OCA/mis-builder>`__
 
 Configuration
 =============
 
-Esses relatórios são estruturados inicialmente com base no **prefixo das
-contas**. Se você estiver utilizando um plano de contas customizado, é
-importante revisar o campo **prefixo da conta** no cadastro do plano de
-contas para garantir que está alinhado com o que foi configurado no
-modelo de relatório.
+Os relatórios selecionam as contas pela **classificação contábil
+brasileira** (as etiquetas de conta do ``l10n_br_coa``), não pelo código
+da conta. Quem usa os planos ``l10n_br_coa_generic`` ou
+``l10n_br_coa_simple`` não precisa configurar nada: eles já vêm
+classificados.
 
-No entanto, essa configuração pode ser ajustada para utilizar **outros
-métodos de identificação** oferecidos pela ferramenta **SIG** (Sistema
-de Informação Gerencial), equivalente ao **MIS** (Management Information
-System) em inglês, implementada pelo módulo **mis_builder**.
+Num **plano de contas próprio**, classifique as contas para que elas
+apareçam: vá em **Faturamento > Configuração > Plano de Contas**, abra a
+conta e preencha **Etiquetas** com a linha de relatório correspondente
+(por exemplo "Ativo / Circulante / Estoques" ou "Resultado / (-)
+Despesas Administrativas").
 
-Para alterar um modelo, siga os passos abaixo:
+Toda conta de resultado leva **duas** etiquetas: a da sua linha na DRE e
+a etiqueta guarda-chuva "Resultado / Contas de Resultado (todas)". É
+essa segunda que alimenta a linha "Resultado do Exercício" do Balanço,
+que é o que faz o ativo fechar com o passivo mais o patrimônio líquido.
 
-1. Acesse **Faturamento > Configuração > Relatórios SIG > Modelos do
-   Relatório SIG**.
-2. Selecione o modelo que deseja editar e ajuste os critérios de
-   identificação, incluindo o **prefixo das contas** ou outro método de
-   identificação disponível.
-3. Certifique-se de que os **prefixos configurados** no modelo do
-   relatório estejam **alinhados** com os prefixos do seu plano de
-   contas.
-
-Para mais detalhes sobre como configurar, consulte a documentação do
-**mis_builder**.
+Conta sem etiqueta simplesmente não entra nos relatórios legais, que é o
+comportamento desejado para contas de controle interno.
 
 Usage
 =====
 
-1. Acesse Faturamento > Relatórios > Relatórios SIG > Relatórios SIG
+O módulo já instala os relatórios prontos. Acesse **Faturamento >
+Relatórios > Relatórios SIG** e escolha um deles:
 
-2. Crie um **novo Relatório**.
+- **Balanço Patrimonial - exercício atual e anterior**: a apresentação
+  comparativa que a Lei 6.404/76 manda publicar (art. 176, § 1º), com a
+  coluna de variação.
+- **DRE - exercício atual e anterior**: a mesma comparação, para o
+  resultado.
+- **DRE - mês e acumulado no exercício**: o acompanhamento gerencial
+  corrente, com o mês, o acumulado desde 1º de janeiro e as duas colunas
+  equivalentes do exercício anterior.
+- **DRE - trimestral**: o trimestre em que se apura o IRPJ e a CSLL no
+  lucro presumido e no lucro real trimestral (Lei 9.430/96, art. 1º),
+  com o trimestre anterior e o mesmo trimestre do exercício passado.
 
-3. Selecione um dos **modelos de relatórios contabeis brasileiro**.
+Para ver outro período, mude a **data base** do relatório: todas as
+colunas se reposicionam juntas, porque são declaradas relativas a ela,
+não por data fixa.
 
-4. Na aba **Layout**, você pode desativar a **expansão das contas** para
-   gerar um relatório mais resumido.
+Depois clique em **Visualizar**, **Imprimir** ou **Exportar**. No modo
+de visualização, clicar no valor de uma linha detalhada abre os
+lançamentos que a compõem.
 
-5. Para selecionar os períodos, siga uma das opções abaixo:
+Períodos
+--------
 
-   -  Selecione diretamente o **intervalo de datas** ou o **nome do
-      período** desejado para obter o relatório referente a esse período
-      específico.
-   -  Ative o **Modo de Comparação** e, na guia **Colunas**, defina
-      quantas colunas deseja, com períodos diferentes. Esses períodos
-      podem ser configurados com **datas fixas** ou períodos relativos.
-      Por exemplo, defina "Tipo de período" como "Ano", com
-      "Deslocamento" = "0" e "Duração" = "1" para o ano corrente (N), e
-      "Deslocamento" = "-1" para o ano anterior (N-1). Lembre-se de
-      ajustar a **data base** do relatório para o ano a ser analisado.
+O módulo instala três tipos de período (**Faturamento > Configuração >
+Intervalos de Datas**), que se geram sozinhos daí em diante:
 
-6. Clique em **Visualizar**, **Imprimir** ou **Exportar** para calcular
-   o relatório e executar a ação desejada.
+- **Mês de competência**, que é o período da apuração de ICMS, IPI, PIS
+  e COFINS e da escrituração mensal do SPED;
+- **Trimestre de apuração**, o trimestre civil do IRPJ e da CSLL;
+- **Exercício social**, de um ano (Lei 6.404/76, art. 175).
 
-7. No modo de visualização, você pode clicar no **valor** das linhas
-   detalhadas para visualizar os **registros contábeis relacionados**.
+Montar um relatório próprio
+---------------------------
+
+Duplique um dos prontos e ajuste as colunas, ou crie um novo escolhendo
+o modelo BP ou DRE. Em **Colunas**, cada coluna pode ser uma data fixa
+ou um período relativo à data base: "Tipo de período" Ano com
+"Deslocamento" 0 é o exercício corrente, -1 o anterior. Marque
+**Acumulado no ano** para a coluna começar em 1º de janeiro.
+
+Uma ressalva do Balanço: a coluna precisa cobrir o exercício (o
+exercício inteiro ou um acumulado desde 1º de janeiro), porque o
+resultado do período é lido do movimento das contas de resultado. Numa
+coluna de mês isolado, o patrimônio líquido exibiria só o resultado
+daquele mês.
 
 Known issues / Roadmap
 ======================
@@ -150,13 +133,38 @@ Fornecer modelos de **Balanço Patrimonial (BP)** e **Demonstrativo de
 Resultados do Exercício (DRE)** conforme a norma **ITG 1000**, com
 versões para:
 
--  **Pequenas Empresas**
--  **Microentidades**
+- **Pequenas Empresas**
+- **Microentidades**
 
 Changelog
 =========
 
+16.0.2.0.0
+----------
 
+- O Balanço e a DRE deixam de ser quatro modelos por prefixo de conta
+  (um par por plano) e passam a ser **um Balanço e uma DRE** que
+  selecionam as contas pela classificação contábil, valendo para
+  qualquer plano, inclusive customizado. Até a versão 14.0 esse papel
+  era dos tipos de conta brasileiros, que a versão 16.0 do Odoo
+  eliminou.
+- O Balanço ganha a linha **Resultado do Exercício**. Sem ela o
+  resultado do período não aparecia em lugar nenhum e o balanço fechava
+  com o ativo maior que o passivo mais o patrimônio líquido, pela
+  diferença exata do lucro.
+- Correções de seleção de conta que vinham desde a migração para a 16.0:
+  os Lucros Acumulados apontavam para uma conta de compensação
+  inexistente, o grupo de Lucros e Prejuízos Acumulados era contado duas
+  vezes no patrimônio líquido, e as linhas de IRPJ e de CSLL apontavam
+  para prefixos que não existem em nenhum dos dois planos.
+- O módulo passa a instalar **relatórios prontos** e os **períodos
+  fiscais brasileiros** (mês de competência, trimestre de apuração e
+  exercício social), em vez de entregar só os modelos.
+
+Os modelos antigos (``balanco_patrimonial_generic``,
+``balanco_patrimonial_simple``, ``dre_generic`` e ``dre_simple``) foram
+removidos. Relatórios montados sobre eles precisam ser refeitos sobre os
+novos.
 
 Bug Tracker
 ===========
@@ -179,9 +187,9 @@ Authors
 Contributors
 ------------
 
--  Luis Felipe Mileo <mileo@kmee.com.br>
--  Diego Paradeda <diego.paradeda@kmee.com.br>
--  Antônio S. Pereira Neto <neto@engenere.one>
+- Luis Felipe Mileo <mileo@kmee.com.br>
+- Diego Paradeda <diego.paradeda@kmee.com.br>
+- Antônio S. Pereira Neto <neto@engenere.one>
 
 Maintainers
 -----------

--- a/l10n_br_mis_report/__manifest__.py
+++ b/l10n_br_mis_report/__manifest__.py
@@ -13,13 +13,23 @@
     "development_status": "Beta",
     "depends": [
         "mis_builder",
+        # os periodos fiscais brasileiros sao date.range.type; o mis_builder ja
+        # depende deste modulo, mas aqui ele e usado diretamente
+        "date_range",
         "l10n_br_coa",
     ],
     "data": [
         "data/mis_report_styles.xml",
+        "data/mis_report_bp.xml",
+        "data/mis_report_dre.xml",
+        # Mantidos para nao apagar, na atualizacao, os relatorios que usuarios
+        # montaram sobre eles. Foram substituidos pelos dois acima; quem nao
+        # os usa pode remover a mao.
         "data/mis_report_bp_generic.xml",
         "data/mis_report_bp_simple.xml",
         "data/mis_report_dre_generic.xml",
         "data/mis_report_dre_simple.xml",
+        "data/date_range_type.xml",
+        "data/mis_report_instance.xml",
     ],
 }

--- a/l10n_br_mis_report/data/date_range_type.xml
+++ b/l10n_br_mis_report/data/date_range_type.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 KMEE
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!--
+      Períodos com que a legislação brasileira manda apurar e demonstrar.
+
+      Eles existem para que as colunas dos relatórios sejam declaradas pelo
+      PERÍODO FISCAL, e não por uma janela móvel de meses. A diferença aparece
+      no trimestre: "os últimos três meses" só coincide com o trimestre de
+      apuração quando a data base cai no fim do trimestre; o trimestre civil
+      coincide sempre, que é o que o IRPJ e a CSLL exigem.
+
+      A geração é automática: o `date_range` já traz um cron diário
+      (`autogenerate_ranges`) que estende cada tipo até o horizonte declarado
+      aqui. A data inicial é relativa à instalação, com dois exercícios de
+      histórico, porque toda demonstração brasileira é comparada com o
+      exercício anterior e sem esse histórico a coluna comparativa nasceria
+      vazia.
+
+      `allow_overlap` fica em falso (o padrão) de propósito: o mis_builder só
+      aceita tipo de período sem sobreposição, porque uma data pertenceria a
+      dois períodos e a coluna ficaria ambígua.
+    -->
+
+    <!--
+      Mês de competência. É o período da apuração de ICMS, IPI, PIS e COFINS,
+      da escrituração mensal do SPED e do acompanhamento gerencial.
+    -->
+    <record id="date_range_type_mes" model="date.range.type">
+        <field name="name">Mês de competência</field>
+        <field name="company_id" eval="False" />
+        <field name="duration_count">1</field>
+        <!-- dateutil.rrule: 0 anual, 1 mensal, 2 semanal, 3 diário -->
+        <field name="unit_of_time">1</field>
+        <field name="name_expr">"%02d/%d" % (date_start.month, date_start.year)</field>
+        <field
+            name="autogeneration_date_start"
+            eval="(DateTime.today() + relativedelta(years=-2, month=1, day=1)).strftime('%Y-%m-%d')"
+        />
+        <field name="autogeneration_count">1</field>
+        <field name="autogeneration_unit">0</field>
+    </record>
+
+    <!--
+      Trimestre civil. É o período de apuração do IRPJ e da CSLL no lucro
+      presumido e no lucro real trimestral (Lei 9.430/96, art. 1º), e é a
+      competência dos registros P030 e K030 da ECF.
+
+      Começa em 1º de janeiro para que os trimestres caiam em jan-mar,
+      abr-jun, jul-set e out-dez. Uma data inicial em outro mês produziria
+      trimestres deslocados, que fecham a soma do ano mas não correspondem a
+      nenhuma apuração.
+    -->
+    <record id="date_range_type_trimestre" model="date.range.type">
+        <field name="name">Trimestre de apuração</field>
+        <field name="company_id" eval="False" />
+        <field name="duration_count">3</field>
+        <field name="unit_of_time">1</field>
+        <field
+            name="name_expr"
+        >"%dT%d" % ((date_start.month - 1) // 3 + 1, date_start.year)</field>
+        <field
+            name="autogeneration_date_start"
+            eval="(DateTime.today() + relativedelta(years=-2, month=1, day=1)).strftime('%Y-%m-%d')"
+        />
+        <field name="autogeneration_count">1</field>
+        <field name="autogeneration_unit">0</field>
+    </record>
+
+    <!--
+      Exercício social. A lei o define com duração de um ano (Lei 6.404/76,
+      art. 175); aqui ele coincide com o ano civil, que é o caso da quase
+      totalidade das empresas brasileiras. Quem encerra em outro mês ajusta a
+      data inicial deste tipo.
+    -->
+    <record id="date_range_type_exercicio" model="date.range.type">
+        <field name="name">Exercício social</field>
+        <field name="company_id" eval="False" />
+        <field name="duration_count">1</field>
+        <field name="unit_of_time">0</field>
+        <field name="name_expr">"%d" % date_start.year</field>
+        <field
+            name="autogeneration_date_start"
+            eval="(DateTime.today() + relativedelta(years=-2, month=1, day=1)).strftime('%Y-%m-%d')"
+        />
+        <field name="autogeneration_count">1</field>
+        <field name="autogeneration_unit">0</field>
+    </record>
+
+    <!--
+      Gera os períodos já na instalação. O `date_range` traz um cron diário
+      que estende os tipos com autogeração configurada, mas ele só roda no dia
+      seguinte: sem esta chamada, o relatório trimestral abriria vazio até lá,
+      e quem instalasse o módulo concluiria que ele não funciona.
+    -->
+    <function model="date.range.type" name="autogenerate_ranges" />
+</odoo>

--- a/l10n_br_mis_report/data/mis_report_bp.xml
+++ b/l10n_br_mis_report/data/mis_report_bp.xml
@@ -1,0 +1,528 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2019 KMEE
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!--
+      Balanço Patrimonial na ordem do art. 178 da Lei 6.404/76.
+
+      As linhas selecionam as contas pela CLASSIFICAÇÃO (as etiquetas do
+      `l10n_br_coa`), não pelo prefixo do código, então este balanço é único e
+      vale para qualquer plano de contas, inclusive customizado.
+
+      A linha "Resultado do Exercício" é o que faz o balanço FECHAR. O Odoo
+      não escritura o resultado do período no patrimônio líquido: ele mantém
+      uma conta de resultado não destinado (`equity_unaffected`, criada com o
+      código 999999, fora da numeração brasileira) e calcula o resultado
+      corrente na hora de apresentar. Um balanço montado só com prefixos de
+      ativo e de passivo deixa o lucro do exercício de fora e apresenta ativo
+      maior que passivo mais patrimônio líquido, pela diferença exata do
+      resultado.
+
+      Por isso o resultado é lido aqui das contas de resultado (`bal`, o
+      movimento do período) e não do saldo de uma conta. A consequência é que
+      a coluna do balanço precisa cobrir o exercício: ou um exercício social
+      inteiro, ou um acumulado desde 1º de janeiro. É exatamente o desenho
+      dos períodos entregues em `date_range_type.xml` e das colunas dos
+      relatórios prontos. Numa coluna de mês isolado, o resultado exibido
+      seria só o do mês.
+
+      Convenção de sinal: as duas colunas são exibidas positivas. Ativo nasce
+      devedor e entra direto; passivo e patrimônio líquido nascem credores e
+      entram com sinal invertido.
+    -->
+    <record id="bp" model="mis.report">
+        <field name="name">BP - Balanço Patrimonial</field>
+        <field name="description">Balanço Patrimonial</field>
+        <field name="move_lines_source" ref="account.model_account_move_line" />
+    </record>
+
+    <record id="bp_header_ativo" model="mis.report.kpi">
+        <field name="sequence">1000</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">ATIVO</field>
+        <field name="name">header_ativo</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_header_circulante" model="mis.report.kpi">
+        <field name="sequence">1010</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">CIRCULANTE</field>
+        <field name="name">header_circulante</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_caixa" model="mis.report.kpi">
+        <field name="sequence">1020</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Caixa e Equivalentes de Caixa</field>
+        <field name="name">caixa</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_assets_cash').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_contas_a_receber" model="mis.report.kpi">
+        <field name="sequence">1030</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Contas a Receber</field>
+        <field name="name">contas_a_receber</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_assets_receivable').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_perdas_estimadas" model="mis.report.kpi">
+        <field name="sequence">1040</field>
+        <field name="report_id" ref="bp" />
+        <field
+            name="description"
+        >(-) Perdas Estimadas com Créditos de Liquidação Duvidosa</field>
+        <field name="name">perdas_estimadas</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_assets_receivable_loss').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_estoques" model="mis.report.kpi">
+        <field name="sequence">1050</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Estoques</field>
+        <field name="name">estoques</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_assets_stock').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_outros_creditos" model="mis.report.kpi">
+        <field name="sequence">1060</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Outros Créditos</field>
+        <field name="name">outros_creditos</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_assets_other_credits').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_ativo_circulante" model="mis.report.kpi">
+        <field name="sequence">1070</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">= TOTAL DO ATIVO CIRCULANTE</field>
+        <field name="name">ativo_circulante</field>
+        <field
+            name="expression"
+        >caixa+contas_a_receber+perdas_estimadas+estoques+outros_creditos</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_header_nao_circulante" model="mis.report.kpi">
+        <field name="sequence">1100</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">NÃO CIRCULANTE</field>
+        <field name="name">header_nao_circulante</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_realizavel_longo_prazo" model="mis.report.kpi">
+        <field name="sequence">1110</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Realizável a Longo Prazo</field>
+        <field name="name">realizavel_longo_prazo</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_non_current_assets_receivable').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_investimentos" model="mis.report.kpi">
+        <field name="sequence">1120</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Investimentos</field>
+        <field name="name">investimentos</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_non_current_investments').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_imobilizado" model="mis.report.kpi">
+        <field name="sequence">1130</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Imobilizado</field>
+        <field name="name">imobilizado</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_fixed_assets').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_depreciacao" model="mis.report.kpi">
+        <field name="sequence">1140</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">(-) Depreciação Acumulada</field>
+        <field name="name">depreciacao</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_fixed_assets_depreciation').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_intangivel" model="mis.report.kpi">
+        <field name="sequence">1150</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Intangível</field>
+        <field name="name">intangivel</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_intangible_assets').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_amortizacao" model="mis.report.kpi">
+        <field name="sequence">1160</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">(-) Amortização Acumulada</field>
+        <field name="name">amortizacao</field>
+        <field
+            name="expression"
+        >+bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_intangible_assets_amortization').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_ativo_nao_circulante" model="mis.report.kpi">
+        <field name="sequence">1170</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">= TOTAL DO ATIVO NÃO CIRCULANTE</field>
+        <field name="name">ativo_nao_circulante</field>
+        <field
+            name="expression"
+        >realizavel_longo_prazo+investimentos+imobilizado+depreciacao+intangivel+amortizacao</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_total_ativo" model="mis.report.kpi">
+        <field name="sequence">1999</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">TOTAL DO ATIVO</field>
+        <field name="name">total_ativo</field>
+        <field name="expression">ativo_circulante+ativo_nao_circulante</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_header_passivo" model="mis.report.kpi">
+        <field name="sequence">2000</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">PASSIVO E PATRIMÔNIO LÍQUIDO</field>
+        <field name="name">header_passivo</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_header_passivo_circulante" model="mis.report.kpi">
+        <field name="sequence">2010</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">CIRCULANTE</field>
+        <field name="name">header_passivo_circulante</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_fornecedores" model="mis.report.kpi">
+        <field name="sequence">2020</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Fornecedores</field>
+        <field name="name">fornecedores</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_liabilities_suppliers').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_emprestimos" model="mis.report.kpi">
+        <field name="sequence">2030</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Empréstimos e Financiamentos</field>
+        <field name="name">emprestimos</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_liabilities_financial').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_obrigacoes_fiscais" model="mis.report.kpi">
+        <field name="sequence">2040</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Obrigações Fiscais</field>
+        <field name="name">obrigacoes_fiscais</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_liabilities_fiscal').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_obrigacoes_trabalhistas" model="mis.report.kpi">
+        <field name="sequence">2050</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Obrigações Trabalhistas</field>
+        <field name="name">obrigacoes_trabalhistas</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_liabilities_labor').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_contas_a_pagar" model="mis.report.kpi">
+        <field name="sequence">2060</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Contas a Pagar</field>
+        <field name="name">contas_a_pagar</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_liabilities_payable').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_provisoes" model="mis.report.kpi">
+        <field name="sequence">2070</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Provisões</field>
+        <field name="name">provisoes</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_current_liabilities_reserve').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_passivo_circulante" model="mis.report.kpi">
+        <field name="sequence">2080</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">= TOTAL DO PASSIVO CIRCULANTE</field>
+        <field name="name">passivo_circulante</field>
+        <field
+            name="expression"
+        >fornecedores+emprestimos+obrigacoes_fiscais+obrigacoes_trabalhistas+contas_a_pagar+provisoes</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_header_passivo_nao_circulante" model="mis.report.kpi">
+        <field name="sequence">2100</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">NÃO CIRCULANTE</field>
+        <field name="name">header_passivo_nao_circulante</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_contas_a_pagar_lp" model="mis.report.kpi">
+        <field name="sequence">2110</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Contas a Pagar a Longo Prazo</field>
+        <field name="name">contas_a_pagar_lp</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_non_current_liabilities').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_financiamentos_lp" model="mis.report.kpi">
+        <field name="sequence">2120</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Financiamentos a Longo Prazo</field>
+        <field name="name">financiamentos_lp</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_non_current_liabilities_loan').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_passivo_nao_circulante" model="mis.report.kpi">
+        <field name="sequence">2130</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">= TOTAL DO PASSIVO NÃO CIRCULANTE</field>
+        <field name="name">passivo_nao_circulante</field>
+        <field name="expression">contas_a_pagar_lp+financiamentos_lp</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_header_pl" model="mis.report.kpi">
+        <field name="sequence">2150</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">PATRIMÔNIO LÍQUIDO</field>
+        <field name="name">header_pl</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_capital_social" model="mis.report.kpi">
+        <field name="sequence">2160</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Capital Social</field>
+        <field name="name">capital_social</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_reservas_capital" model="mis.report.kpi">
+        <field name="sequence">2170</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Reservas de Capital</field>
+        <field name="name">reservas_capital</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital_reserve').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_reservas_lucros" model="mis.report.kpi">
+        <field name="sequence">2180</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Reservas de Lucros</field>
+        <field name="name">reservas_lucros</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_profit_reserve').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_lucros_acumulados" model="mis.report.kpi">
+        <field name="sequence">2190</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Lucros Acumulados</field>
+        <field name="name">lucros_acumulados</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_prejuizos_acumulados" model="mis.report.kpi">
+        <field name="sequence">2200</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">(-) Prejuízos Acumulados</field>
+        <field name="name">prejuizos_acumulados</field>
+        <field
+            name="expression"
+        >-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_losses').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_resultado_anteriores" model="mis.report.kpi">
+        <field name="sequence">2210</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Resultado de Exercícios Anteriores a Destinar</field>
+        <field name="name">resultado_anteriores</field>
+        <field
+            name="expression"
+        >-bale[('account_type', '=', 'equity_unaffected')]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="bp_resultado_exercicio" model="mis.report.kpi">
+        <field name="sequence">2220</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">Resultado do Exercício</field>
+        <field name="name">resultado_exercicio</field>
+        <field
+            name="expression"
+        >-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_result').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="bp_patrimonio_liquido" model="mis.report.kpi">
+        <field name="sequence">2230</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">= TOTAL DO PATRIMÔNIO LÍQUIDO</field>
+        <field name="name">patrimonio_liquido</field>
+        <field
+            name="expression"
+        >capital_social+reservas_capital+reservas_lucros+lucros_acumulados+prejuizos_acumulados+resultado_anteriores+resultado_exercicio</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="bp_total_passivo" model="mis.report.kpi">
+        <field name="sequence">2999</field>
+        <field name="report_id" ref="bp" />
+        <field name="description">TOTAL DO PASSIVO E DO PATRIMÔNIO LÍQUIDO</field>
+        <field name="name">total_passivo</field>
+        <field
+            name="expression"
+        >passivo_circulante+passivo_nao_circulante+patrimonio_liquido</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+</odoo>

--- a/l10n_br_mis_report/data/mis_report_bp_generic.xml
+++ b/l10n_br_mis_report/data/mis_report_bp_generic.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
+    <!--
+      DESCONTINUADO. Substituído pelo Balanço e pela DRE únicos, que
+      selecionam as contas pela classificação contábil e valem para qualquer
+      plano. Este modelo seleciona por prefixo de código e, por isso, só
+      funciona no plano para o qual foi escrito.
+
+      Ele continua aqui para que a atualização do módulo não apague os
+      relatórios que já foram montados sobre ele. Não recebe correção: os
+      defeitos conhecidos (falta a linha de resultado do exercício, então o
+      balanço não fecha; contas de Lucros Acumulados e de IRPJ e CSLL
+      apontando para prefixos inexistentes) estão corrigidos apenas nos
+      modelos novos.
+    -->
     <record id="balanco_patrimonial_generic" model="mis.report">
-        <field name="name">BP (l10n_br_coa_generic)</field>
+        <field name="name">BP (l10n_br_coa_generic) (descontinuado)</field>
         <field name="description">Balanço Patrimonial</field>
         <field name="move_lines_source" ref="account.model_account_move_line" />
     </record>

--- a/l10n_br_mis_report/data/mis_report_bp_simple.xml
+++ b/l10n_br_mis_report/data/mis_report_bp_simple.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
+    <!--
+      DESCONTINUADO. Substituído pelo Balanço e pela DRE únicos, que
+      selecionam as contas pela classificação contábil e valem para qualquer
+      plano. Este modelo seleciona por prefixo de código e, por isso, só
+      funciona no plano para o qual foi escrito.
+
+      Ele continua aqui para que a atualização do módulo não apague os
+      relatórios que já foram montados sobre ele. Não recebe correção: os
+      defeitos conhecidos (falta a linha de resultado do exercício, então o
+      balanço não fecha; contas de Lucros Acumulados e de IRPJ e CSLL
+      apontando para prefixos inexistentes) estão corrigidos apenas nos
+      modelos novos.
+    -->
     <record id="balanco_patrimonial_simple" model="mis.report">
-        <field name="name">BP (l10n_br_coa_simple)</field>
+        <field name="name">BP (l10n_br_coa_simple) (descontinuado)</field>
         <field name="description">Balanço Patrimonial</field>
         <field name="move_lines_source" ref="account.model_account_move_line" />
     </record>

--- a/l10n_br_mis_report/data/mis_report_dre.xml
+++ b/l10n_br_mis_report/data/mis_report_dre.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2019 KMEE
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!--
+      Demonstração do Resultado do Exercício na ordem do art. 187 da Lei
+      6.404/76: receita bruta, deduções, receita líquida, custo, lucro bruto,
+      despesas operacionais, resultado financeiro, resultado antes dos
+      tributos sobre o lucro, provisão de CSLL e de IRPJ, resultado líquido.
+
+      As linhas selecionam as contas pela CLASSIFICAÇÃO (as etiquetas do
+      `l10n_br_coa`), não pelo prefixo do código. Por isso esta demonstração é
+      única e vale para qualquer plano de contas, inclusive customizado: basta
+      que as contas estejam classificadas. Até a versão 14.0 o mesmo papel era
+      cumprido pelos tipos de conta brasileiros, que a versão 16.0 do Odoo
+      eliminou.
+
+      Convenção de sinal: toda linha é exibida positiva quando é o que o
+      rótulo diz. Receita nasce credora, então entra com sinal invertido;
+      despesa nasce devedora e entra direto. Os subtotais fazem a conta com o
+      sinal explícito, o que evita a soma de um resultado financeiro que na
+      verdade era um custo.
+    -->
+    <record id="dre" model="mis.report">
+        <field name="name">DRE - Demonstração do Resultado do Exercício</field>
+        <field name="description">Demonstração do Resultado do Exercício</field>
+        <field name="move_lines_source" ref="account.model_account_move_line" />
+    </record>
+
+    <record id="dre_header_receita" model="mis.report.kpi">
+        <field name="sequence">10</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">RECEITA BRUTA DE VENDAS E SERVIÇOS</field>
+        <field name="name">header_receita</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dre_receita_bruta" model="mis.report.kpi">
+        <field name="sequence">20</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">Receita Bruta de Vendas e Serviços</field>
+        <field name="name">receita_bruta</field>
+        <field
+            name="expression"
+        >-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_revenue').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_deducoes_receita" model="mis.report.kpi">
+        <field name="sequence">30</field>
+        <field name="report_id" ref="dre" />
+        <field
+            name="description"
+        >(-) Deduções de Tributos, Abatimentos e Devoluções</field>
+        <field name="name">deducoes_receita</field>
+        <field
+            name="expression"
+        >+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_revenue_deduction').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_receita_liquida" model="mis.report.kpi">
+        <field name="sequence">40</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">= RECEITA LÍQUIDA</field>
+        <field name="name">receita_liquida</field>
+        <field name="expression">receita_bruta-deducoes_receita</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dre_header_custo" model="mis.report.kpi">
+        <field name="sequence">50</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">(-) CUSTO DAS VENDAS</field>
+        <field name="name">header_custo</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dre_custo_vendas" model="mis.report.kpi">
+        <field name="sequence">60</field>
+        <field name="report_id" ref="dre" />
+        <field
+            name="description"
+        >Custo dos Produtos, Mercadorias e Serviços Vendidos</field>
+        <field name="name">custo_vendas</field>
+        <field
+            name="expression"
+        >+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_direct_costs').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_lucro_bruto" model="mis.report.kpi">
+        <field name="sequence">70</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">= LUCRO BRUTO</field>
+        <field name="name">lucro_bruto</field>
+        <field name="expression">receita_liquida-custo_vendas</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dre_header_despesas" model="mis.report.kpi">
+        <field name="sequence">80</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">(-) DESPESAS OPERACIONAIS</field>
+        <field name="name">header_despesas</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dre_despesas_administrativas" model="mis.report.kpi">
+        <field name="sequence">90</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">Despesas Administrativas</field>
+        <field name="name">despesas_administrativas</field>
+        <field
+            name="expression"
+        >+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_admin_expenses').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_despesas_vendas" model="mis.report.kpi">
+        <field name="sequence">100</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">Despesas com Vendas</field>
+        <field name="name">despesas_vendas</field>
+        <field
+            name="expression"
+        >+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_sale_expenses').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_despesas_gerais" model="mis.report.kpi">
+        <field name="sequence">110</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">Outras Despesas Gerais</field>
+        <field name="name">despesas_gerais</field>
+        <field
+            name="expression"
+        >+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_other_general_expenses').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_despesas_operacionais" model="mis.report.kpi">
+        <field name="sequence">120</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">= TOTAL DAS DESPESAS OPERACIONAIS</field>
+        <field name="name">despesas_operacionais</field>
+        <field
+            name="expression"
+        >despesas_administrativas+despesas_vendas+despesas_gerais</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dre_resultado_operacional" model="mis.report.kpi">
+        <field name="sequence">130</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">= RESULTADO OPERACIONAL</field>
+        <field name="name">resultado_operacional</field>
+        <field name="expression">lucro_bruto-despesas_operacionais</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dre_header_financeiro" model="mis.report.kpi">
+        <field name="sequence">140</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">(+/-) RESULTADO FINANCEIRO</field>
+        <field name="name">header_financeiro</field>
+        <field name="type">str</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dre_receitas_financeiras" model="mis.report.kpi">
+        <field name="sequence">150</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">Receitas Financeiras</field>
+        <field name="name">receitas_financeiras</field>
+        <field
+            name="expression"
+        >-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_revenue_financial').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_despesas_financeiras" model="mis.report.kpi">
+        <field name="sequence">160</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">(-) Despesas Financeiras</field>
+        <field name="name">despesas_financeiras</field>
+        <field
+            name="expression"
+        >+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_expenses_financial').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_resultado_financeiro" model="mis.report.kpi">
+        <field name="sequence">170</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">= RESULTADO FINANCEIRO</field>
+        <field name="name">resultado_financeiro</field>
+        <field name="expression">receitas_financeiras-despesas_financeiras</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dre_outras_receitas_despesas" model="mis.report.kpi">
+        <field name="sequence">180</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">(+/-) Outras Receitas e Despesas Operacionais</field>
+        <field name="name">outras_receitas_despesas</field>
+        <field
+            name="expression"
+        >-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_other_operating_results').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_resultado_antes_tributos" model="mis.report.kpi">
+        <field name="sequence">190</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">= RESULTADO ANTES DO IRPJ E DA CSLL</field>
+        <field name="name">resultado_antes_tributos</field>
+        <field
+            name="expression"
+        >resultado_operacional+resultado_financeiro+outras_receitas_despesas</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dre_csll" model="mis.report.kpi">
+        <field name="sequence">200</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">(-) Contribuição Social sobre o Lucro Líquido</field>
+        <field name="name">csll</field>
+        <field
+            name="expression"
+        >+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_expense_csll').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_irpj" model="mis.report.kpi">
+        <field name="sequence">210</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">(-) Imposto de Renda da Pessoa Jurídica</field>
+        <field name="name">irpj</field>
+        <field
+            name="expression"
+        >+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_expense_irpj').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="auto_expand_accounts" eval="True" />
+    </record>
+
+    <record id="dre_resultado_liquido" model="mis.report.kpi">
+        <field name="sequence">220</field>
+        <field name="report_id" ref="dre" />
+        <field name="description">= RESULTADO LÍQUIDO DO EXERCÍCIO</field>
+        <field name="name">resultado_liquido</field>
+        <field name="expression">resultado_antes_tributos-csll-irpj</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id" ref="mis_report_style_l10n_br_negrito" />
+    </record>
+
+</odoo>

--- a/l10n_br_mis_report/data/mis_report_dre_generic.xml
+++ b/l10n_br_mis_report/data/mis_report_dre_generic.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
+    <!--
+      DESCONTINUADO. Substituído pelo Balanço e pela DRE únicos, que
+      selecionam as contas pela classificação contábil e valem para qualquer
+      plano. Este modelo seleciona por prefixo de código e, por isso, só
+      funciona no plano para o qual foi escrito.
+
+      Ele continua aqui para que a atualização do módulo não apague os
+      relatórios que já foram montados sobre ele. Não recebe correção: os
+      defeitos conhecidos (falta a linha de resultado do exercício, então o
+      balanço não fecha; contas de Lucros Acumulados e de IRPJ e CSLL
+      apontando para prefixos inexistentes) estão corrigidos apenas nos
+      modelos novos.
+    -->
     <record id="dre_generic" model="mis.report">
-        <field name="name">DRE (l10n_br_coa_generic)</field>
+        <field name="name">DRE (l10n_br_coa_generic) (descontinuado)</field>
         <field name="description">Demonstração do Resultado do Exercício</field>
         <field name="move_lines_source" ref="account.model_account_move_line" />
     </record>

--- a/l10n_br_mis_report/data/mis_report_dre_simple.xml
+++ b/l10n_br_mis_report/data/mis_report_dre_simple.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
+    <!--
+      DESCONTINUADO. Substituído pelo Balanço e pela DRE únicos, que
+      selecionam as contas pela classificação contábil e valem para qualquer
+      plano. Este modelo seleciona por prefixo de código e, por isso, só
+      funciona no plano para o qual foi escrito.
+
+      Ele continua aqui para que a atualização do módulo não apague os
+      relatórios que já foram montados sobre ele. Não recebe correção: os
+      defeitos conhecidos (falta a linha de resultado do exercício, então o
+      balanço não fecha; contas de Lucros Acumulados e de IRPJ e CSLL
+      apontando para prefixos inexistentes) estão corrigidos apenas nos
+      modelos novos.
+    -->
     <record id="dre_simple" model="mis.report">
-        <field name="name">DRE (l10n_br_coa_simple)</field>
+        <field name="name">DRE (l10n_br_coa_simple) (descontinuado)</field>
         <field name="description">Demonstração do Resultado do Exercício</field>
         <field name="move_lines_source" ref="account.model_account_move_line" />
     </record>

--- a/l10n_br_mis_report/data/mis_report_instance.xml
+++ b/l10n_br_mis_report/data/mis_report_instance.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 KMEE
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!--
+      Relatórios prontos para usar. Sem eles o módulo entregava só os modelos,
+      e cada usuário tinha que montar coluna por coluna antes de ver qualquer
+      número.
+
+      As colunas são declaradas por período RELATIVO à data base do relatório,
+      nunca por data fixa: assim o mesmo relatório serve todo mês e todo
+      exercício, sem manutenção. Mudar a data base do relatório reposiciona
+      todas as colunas de uma vez.
+
+      Cada relatório aqui responde a uma exigência concreta:
+
+      - o comparativo com o exercício anterior é o que a Lei 6.404/76 manda
+        publicar (art. 176, § 1º: as demonstrações de cada exercício são
+        publicadas com a indicação dos valores correspondentes do exercício
+        anterior);
+      - o mês com acumulado é o acompanhamento gerencial corrente, no mesmo
+        recorte da apuração mensal de ICMS, IPI, PIS e COFINS;
+      - o trimestral é o período em que se apura IRPJ e CSLL no lucro
+        presumido e no lucro real trimestral (Lei 9.430/96, art. 1º), e é a
+        competência dos registros P030 e K030 da ECF.
+
+      `company_id` fica vazio de propósito: a regra de registro do mis_builder
+      trata empresa vazia como disponível em qualquer empresa, e o relatório
+      lê os dados da empresa em que o usuário estiver.
+
+      O Balanço só fecha em coluna que cubra o exercício (exercício inteiro ou
+      acumulado desde 1º de janeiro), porque o resultado do período é lido do
+      movimento das contas de resultado. Por isso não há Balanço de mês
+      isolado aqui.
+    -->
+    <record id="instance_bp_exercicio" model="mis.report.instance">
+        <field name="name">Balanço Patrimonial - exercício atual e anterior</field>
+        <field name="report_id" ref="bp" />
+        <field name="sequence">10</field>
+        <field name="company_id" eval="False" />
+        <field name="target_move">posted</field>
+        <field name="comparison_mode" eval="True" />
+        <field name="display_columns_description" eval="True" />
+    </record>
+
+    <record id="instance_bp_exercicio_ant" model="mis.report.instance.period">
+        <field name="name">Exercício anterior</field>
+        <field name="report_instance_id" ref="instance_bp_exercicio" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">10</field>
+        <field name="type">y</field>
+        <field name="offset">-1</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_bp_exercicio_atual" model="mis.report.instance.period">
+        <field name="name">Exercício atual</field>
+        <field name="report_instance_id" ref="instance_bp_exercicio" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">20</field>
+        <field name="type">y</field>
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_bp_exercicio_var" model="mis.report.instance.period">
+        <field name="name">Variação</field>
+        <field name="report_instance_id" ref="instance_bp_exercicio" />
+        <field name="source">cmpcol</field>
+        <field name="mode">none</field>
+        <field name="sequence">30</field>
+        <field name="source_cmpcol_from_id" ref="instance_bp_exercicio_ant" />
+        <field name="source_cmpcol_to_id" ref="instance_bp_exercicio_atual" />
+    </record>
+
+    <record id="instance_dre_exercicio" model="mis.report.instance">
+        <field name="name">DRE - exercício atual e anterior</field>
+        <field name="report_id" ref="dre" />
+        <field name="sequence">20</field>
+        <field name="company_id" eval="False" />
+        <field name="target_move">posted</field>
+        <field name="comparison_mode" eval="True" />
+        <field name="display_columns_description" eval="True" />
+    </record>
+
+    <record id="instance_dre_exercicio_ant" model="mis.report.instance.period">
+        <field name="name">Exercício anterior</field>
+        <field name="report_instance_id" ref="instance_dre_exercicio" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">10</field>
+        <field name="type">y</field>
+        <field name="offset">-1</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dre_exercicio_atual" model="mis.report.instance.period">
+        <field name="name">Exercício atual</field>
+        <field name="report_instance_id" ref="instance_dre_exercicio" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">20</field>
+        <field name="type">y</field>
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dre_exercicio_var" model="mis.report.instance.period">
+        <field name="name">Variação</field>
+        <field name="report_instance_id" ref="instance_dre_exercicio" />
+        <field name="source">cmpcol</field>
+        <field name="mode">none</field>
+        <field name="sequence">30</field>
+        <field name="source_cmpcol_from_id" ref="instance_dre_exercicio_ant" />
+        <field name="source_cmpcol_to_id" ref="instance_dre_exercicio_atual" />
+    </record>
+
+    <record id="instance_dre_mensal" model="mis.report.instance">
+        <field name="name">DRE - mês e acumulado no exercício</field>
+        <field name="report_id" ref="dre" />
+        <field name="sequence">30</field>
+        <field name="company_id" eval="False" />
+        <field name="target_move">posted</field>
+        <field name="comparison_mode" eval="True" />
+        <field name="display_columns_description" eval="True" />
+    </record>
+
+    <record id="instance_dre_mensal_mes_ant" model="mis.report.instance.period">
+        <field name="name">Mesmo mês do exercício anterior</field>
+        <field name="report_instance_id" ref="instance_dre_mensal" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">10</field>
+        <field name="type">m</field>
+        <field name="offset">-12</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dre_mensal_acum_ant" model="mis.report.instance.period">
+        <field name="name">Acumulado do exercício anterior</field>
+        <field name="report_instance_id" ref="instance_dre_mensal" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">20</field>
+        <field name="type">m</field>
+        <field name="offset">-12</field>
+        <field name="duration">1</field>
+        <field name="is_ytd" eval="True" />
+    </record>
+
+    <record id="instance_dre_mensal_mes" model="mis.report.instance.period">
+        <field name="name">Mês</field>
+        <field name="report_instance_id" ref="instance_dre_mensal" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">30</field>
+        <field name="type">m</field>
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dre_mensal_acum" model="mis.report.instance.period">
+        <field name="name">Acumulado no exercício</field>
+        <field name="report_instance_id" ref="instance_dre_mensal" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">40</field>
+        <field name="type">m</field>
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+        <field name="is_ytd" eval="True" />
+    </record>
+
+    <record id="instance_dre_trimestral" model="mis.report.instance">
+        <field name="name">DRE - trimestral (apuração do IRPJ e da CSLL)</field>
+        <field name="report_id" ref="dre" />
+        <field name="sequence">40</field>
+        <field name="company_id" eval="False" />
+        <field name="target_move">posted</field>
+        <field name="comparison_mode" eval="True" />
+        <field name="display_columns_description" eval="True" />
+    </record>
+
+    <record id="instance_dre_trimestral_tri_ant_ano" model="mis.report.instance.period">
+        <field name="name">Mesmo trimestre do exercício anterior</field>
+        <field name="report_instance_id" ref="instance_dre_trimestral" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">10</field>
+        <field name="type">date_range</field>
+        <field name="date_range_type_id" ref="date_range_type_trimestre" />
+        <field name="offset">-4</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dre_trimestral_tri_ant" model="mis.report.instance.period">
+        <field name="name">Trimestre anterior</field>
+        <field name="report_instance_id" ref="instance_dre_trimestral" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">20</field>
+        <field name="type">date_range</field>
+        <field name="date_range_type_id" ref="date_range_type_trimestre" />
+        <field name="offset">-1</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dre_trimestral_tri" model="mis.report.instance.period">
+        <field name="name">Trimestre atual</field>
+        <field name="report_instance_id" ref="instance_dre_trimestral" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">30</field>
+        <field name="type">date_range</field>
+        <field name="date_range_type_id" ref="date_range_type_trimestre" />
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+    </record>
+
+</odoo>

--- a/l10n_br_mis_report/readme/CONFIGURE.md
+++ b/l10n_br_mis_report/readme/CONFIGURE.md
@@ -1,11 +1,17 @@
-Esses relatórios são estruturados inicialmente com base no **prefixo das contas**. Se você estiver utilizando um plano de contas customizado, é importante revisar o campo **prefixo da conta** no cadastro do plano de contas para garantir que está alinhado com o que foi configurado no modelo de relatório.
+Os relatórios selecionam as contas pela **classificação contábil brasileira**
+(as etiquetas de conta do `l10n_br_coa`), não pelo código da conta. Quem usa os
+planos `l10n_br_coa_generic` ou `l10n_br_coa_simple` não precisa configurar
+nada: eles já vêm classificados.
 
-No entanto, essa configuração pode ser ajustada para utilizar **outros métodos de identificação** oferecidos pela ferramenta **SIG** (Sistema de Informação Gerencial), equivalente ao **MIS** (Management Information System) em inglês, implementada pelo módulo **mis_builder**.
+Num **plano de contas próprio**, classifique as contas para que elas apareçam:
+vá em **Faturamento > Configuração > Plano de Contas**, abra a conta e preencha
+**Etiquetas** com a linha de relatório correspondente (por exemplo "Ativo /
+Circulante / Estoques" ou "Resultado / (-) Despesas Administrativas").
 
-Para alterar um modelo, siga os passos abaixo:
+Toda conta de resultado leva **duas** etiquetas: a da sua linha na DRE e a
+etiqueta guarda-chuva "Resultado / Contas de Resultado (todas)". É essa segunda
+que alimenta a linha "Resultado do Exercício" do Balanço, que é o que faz o
+ativo fechar com o passivo mais o patrimônio líquido.
 
-1. Acesse **Faturamento \> Configuração \> Relatórios SIG \> Modelos do Relatório SIG**.
-2. Selecione o modelo que deseja editar e ajuste os critérios de identificação, incluindo o **prefixo das contas** ou outro método de identificação disponível.
-3. Certifique-se de que os **prefixos configurados** no modelo do relatório estejam **alinhados** com os prefixos do seu plano de contas.
-
-Para mais detalhes sobre como configurar, consulte a documentação do **mis_builder**.
+Conta sem etiqueta simplesmente não entra nos relatórios legais, que é o
+comportamento desejado para contas de controle interno.

--- a/l10n_br_mis_report/readme/DESCRIPTION.md
+++ b/l10n_br_mis_report/readme/DESCRIPTION.md
@@ -1,19 +1,7 @@
-Este módulo implementa **Modelos de Relatórios Contábeis Brasileiros**, como o **Demonstrativo de Resultados do Exercício (DRE)** e o **Balanço Patrimonial (BP)**, baseados na norma **ITG 1000**. Ele permite que pequenas empresas e microentidades gerem relatórios contábeis de acordo com os padrões brasileiros, com a flexibilidade de personalizar os modelos conforme o plano de contas de cada empresa.
+Balanço Patrimonial e Demonstração do Resultado do Exercício brasileiros para o
+mis_builder, com os relatórios já montados e os períodos em que a legislação
+brasileira manda apurar e demonstrar.
 
-**Nota:** Embora esses modelos sejam **inspirados no ITG 1000**, eles **não correspondem exatamente ao modelo proposto pela norma**. Além disso, pode haver **diferenças** em relação às versões mais recentes do ITG 1000.
-
-Para mais informações, consulte as [Normas Simplificadas para PMEs no site do CFC](https://cfc.org.br/tecnica/normas-brasileiras-de-contabilidade/normas-simplificadas-para-pmes/).
-
-**Observação:** Esses modelos são um **ponto de partida** e precisam ser **ajustados** de acordo com o plano de contas da sua empresa. Por padrão, eles estão configurados com os prefixos das contas contábeis da **localização brasileira da OCA**. Para saber mais sobre como configurar corretamente esses modelos, consulte a **seção de configuração**.
-
-#### Balanço Patrimonial (BP)
-
-Abaixo está um exemplo visual de um **Balanço Patrimonial** inspirado no ITG 1000:
-
-![Balanço Patrimonial](../static/description/bp.png)
-
-#### Demonstrativo de Resultados do Exercício (DRE)
-
-Abaixo está um exemplo visual de um **DRE** (Demonstrativo de Resultados do Exercício) inspirado no ITG 1000:
-
-![DRE](../static/description/dre.png)
+O Balanço segue a ordem do art. 178 da Lei 6.404/76 e a DRE a do art. 187.
+As contas são selecionadas pela classificação contábil, então os mesmos
+relatórios servem qualquer plano de contas.

--- a/l10n_br_mis_report/readme/HISTORY.md
+++ b/l10n_br_mis_report/readme/HISTORY.md
@@ -1,1 +1,22 @@
+## 16.0.2.0.0
 
+- O Balanço e a DRE deixam de ser quatro modelos por prefixo de conta (um par
+  por plano) e passam a ser **um Balanço e uma DRE** que selecionam as contas
+  pela classificação contábil, valendo para qualquer plano, inclusive
+  customizado. Até a versão 14.0 esse papel era dos tipos de conta brasileiros,
+  que a versão 16.0 do Odoo eliminou.
+- O Balanço ganha a linha **Resultado do Exercício**. Sem ela o resultado do
+  período não aparecia em lugar nenhum e o balanço fechava com o ativo maior
+  que o passivo mais o patrimônio líquido, pela diferença exata do lucro.
+- Correções de seleção de conta que vinham desde a migração para a 16.0: os
+  Lucros Acumulados apontavam para uma conta de compensação inexistente, o
+  grupo de Lucros e Prejuízos Acumulados era contado duas vezes no patrimônio
+  líquido, e as linhas de IRPJ e de CSLL apontavam para prefixos que não
+  existem em nenhum dos dois planos.
+- O módulo passa a instalar **relatórios prontos** e os **períodos fiscais
+  brasileiros** (mês de competência, trimestre de apuração e exercício social),
+  em vez de entregar só os modelos.
+
+Os modelos antigos (`balanco_patrimonial_generic`, `balanco_patrimonial_simple`,
+`dre_generic` e `dre_simple`) foram removidos. Relatórios montados sobre eles
+precisam ser refeitos sobre os novos.

--- a/l10n_br_mis_report/readme/USAGE.md
+++ b/l10n_br_mis_report/readme/USAGE.md
@@ -1,17 +1,43 @@
-1.  Acesse Faturamento \> Relatórios \> Relatórios SIG \> Relatórios SIG
+O módulo já instala os relatórios prontos. Acesse **Faturamento > Relatórios >
+Relatórios SIG** e escolha um deles:
 
-2.  Crie um **novo Relatório**.
+- **Balanço Patrimonial - exercício atual e anterior**: a apresentação
+  comparativa que a Lei 6.404/76 manda publicar (art. 176, § 1º), com a coluna
+  de variação.
+- **DRE - exercício atual e anterior**: a mesma comparação, para o resultado.
+- **DRE - mês e acumulado no exercício**: o acompanhamento gerencial corrente,
+  com o mês, o acumulado desde 1º de janeiro e as duas colunas equivalentes do
+  exercício anterior.
+- **DRE - trimestral**: o trimestre em que se apura o IRPJ e a CSLL no lucro
+  presumido e no lucro real trimestral (Lei 9.430/96, art. 1º), com o trimestre
+  anterior e o mesmo trimestre do exercício passado.
 
-3.  Selecione um dos **modelos de relatórios contabeis brasileiro**.
+Para ver outro período, mude a **data base** do relatório: todas as colunas se
+reposicionam juntas, porque são declaradas relativas a ela, não por data fixa.
 
-4.  Na aba **Layout**, você pode desativar a **expansão das contas** para gerar um relatório mais resumido.
+Depois clique em **Visualizar**, **Imprimir** ou **Exportar**. No modo de
+visualização, clicar no valor de uma linha detalhada abre os lançamentos que a
+compõem.
 
-5. Para selecionar os períodos, siga uma das opções abaixo:
+## Períodos
 
-    - Selecione diretamente o **intervalo de datas** ou o **nome do período** desejado para obter o relatório referente a esse período específico.
-    - Ative o **Modo de Comparação** e, na guia **Colunas**, defina quantas colunas deseja, com períodos diferentes. Esses períodos podem ser configurados com **datas fixas** ou períodos relativos. Por exemplo, defina "Tipo de período" como "Ano", com "Deslocamento" = "0" e "Duração" = "1" para o ano corrente (N), e "Deslocamento" = "-1" para o ano anterior (N-1). Lembre-se de ajustar a **data base** do relatório para o ano a ser analisado.
+O módulo instala três tipos de período (**Faturamento > Configuração >
+Intervalos de Datas**), que se geram sozinhos daí em diante:
 
+- **Mês de competência**, que é o período da apuração de ICMS, IPI, PIS e
+  COFINS e da escrituração mensal do SPED;
+- **Trimestre de apuração**, o trimestre civil do IRPJ e da CSLL;
+- **Exercício social**, de um ano (Lei 6.404/76, art. 175).
 
-6. Clique em **Visualizar**, **Imprimir** ou **Exportar** para calcular o relatório e executar a ação desejada.
+## Montar um relatório próprio
 
-7. No modo de visualização, você pode clicar no **valor** das linhas detalhadas para visualizar os **registros contábeis relacionados**.
+Duplique um dos prontos e ajuste as colunas, ou crie um novo escolhendo o
+modelo BP ou DRE. Em **Colunas**, cada coluna pode ser uma data fixa ou um
+período relativo à data base: "Tipo de período" Ano com "Deslocamento" 0 é o
+exercício corrente, -1 o anterior. Marque **Acumulado no ano** para a coluna
+começar em 1º de janeiro.
+
+Uma ressalva do Balanço: a coluna precisa cobrir o exercício (o exercício
+inteiro ou um acumulado desde 1º de janeiro), porque o resultado do período é
+lido do movimento das contas de resultado. Numa coluna de mês isolado, o
+patrimônio líquido exibiria só o resultado daquele mês.

--- a/l10n_br_mis_report/static/description/index.html
+++ b/l10n_br_mis_report/static/description/index.html
@@ -370,54 +370,38 @@ ul.auto-toc {
 !! source digest: sha256:2084eb600d57917460125c75a02ade11230d4db04b3fc2cb35e616f2949cf06e
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/l10n-brazil/tree/16.0/l10n_br_mis_report"><img alt="OCA/l10n-brazil" src="https://img.shields.io/badge/github-OCA%2Fl10n--brazil-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/l10n-brazil-16-0/l10n-brazil-16-0-l10n_br_mis_report"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/l10n-brazil&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>Este módulo implementa <strong>Modelos de Relatórios Contábeis Brasileiros</strong>,
-como o <strong>Demonstrativo de Resultados do Exercício (DRE)</strong> e o <strong>Balanço
-Patrimonial (BP)</strong>, baseados na norma <strong>ITG 1000</strong>. Ele permite que
-pequenas empresas e microentidades gerem relatórios contábeis de acordo
-com os padrões brasileiros, com a flexibilidade de personalizar os
-modelos conforme o plano de contas de cada empresa.</p>
-<p><strong>Nota:</strong> Embora esses modelos sejam <strong>inspirados no ITG 1000</strong>, eles
-<strong>não correspondem exatamente ao modelo proposto pela norma</strong>. Além
-disso, pode haver <strong>diferenças</strong> em relação às versões mais recentes do
-ITG 1000.</p>
-<p>Para mais informações, consulte as <a class="reference external" href="https://cfc.org.br/tecnica/normas-brasileiras-de-contabilidade/normas-simplificadas-para-pmes/">Normas Simplificadas para PMEs no
-site do
-CFC</a>.</p>
-<p><strong>Observação:</strong> Esses modelos são um <strong>ponto de partida</strong> e precisam ser
-<strong>ajustados</strong> de acordo com o plano de contas da sua empresa. Por
-padrão, eles estão configurados com os prefixos das contas contábeis da
-<strong>localização brasileira da OCA</strong>. Para saber mais sobre como configurar
-corretamente esses modelos, consulte a <strong>seção de configuração</strong>.</p>
-<div class="section" id="balanco-patrimonial-bp">
-<h1>Balanço Patrimonial (BP)</h1>
-<p>Abaixo está um exemplo visual de um <strong>Balanço Patrimonial</strong> inspirado no
-ITG 1000:</p>
-<p><img alt="Balanço Patrimonial" src="https://raw.githubusercontent.com/OCA/l10n-brazil/16.0/l10n_br_mis_report/static/description/bp.png" /></p>
-</div>
-<div class="section" id="demonstrativo-de-resultados-do-exercicio-dre">
-<h1>Demonstrativo de Resultados do Exercício (DRE)</h1>
-<p>Abaixo está um exemplo visual de um <strong>DRE</strong> (Demonstrativo de Resultados
-do Exercício) inspirado no ITG 1000:</p>
-<p><img alt="DRE" src="https://raw.githubusercontent.com/OCA/l10n-brazil/16.0/l10n_br_mis_report/static/description/dre.png" /></p>
+<p>Balanço Patrimonial e Demonstração do Resultado do Exercício brasileiros
+para o mis_builder, com os relatórios já montados e os períodos em que a
+legislação brasileira manda apurar e demonstrar.</p>
+<p>O Balanço segue a ordem do art. 178 da Lei 6.404/76 e a DRE a do art.
+187. As contas são selecionadas pela classificação contábil, então os
+mesmos relatórios servem qualquer plano de contas.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="toc-entry-1">Installation</a></li>
 <li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a></li>
-<li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-4">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#changelog" id="toc-entry-5">Changelog</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-6">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-7">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-8">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-9">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-10">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a><ul>
+<li><a class="reference internal" href="#periodos" id="toc-entry-4">Períodos</a></li>
+<li><a class="reference internal" href="#montar-um-relatorio-proprio" id="toc-entry-5">Montar um relatório próprio</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-6">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-7">Changelog</a><ul>
+<li><a class="reference internal" href="#section-1" id="toc-entry-8">16.0.2.0.0</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-9">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-10">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-11">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-12">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-13">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="installation">
-<h2><a class="toc-backref" href="#toc-entry-1">Installation</a></h2>
+<h1><a class="toc-backref" href="#toc-entry-1">Installation</a></h1>
 <p>Este módulo tem como dependência o módulo <tt class="docutils literal">mis_builder</tt>, que pode ser
 encontrado nos seguintes locais:</p>
 <ul class="simple">
@@ -427,59 +411,74 @@ Shop</a></li>
 </ul>
 </div>
 <div class="section" id="configuration">
-<h2><a class="toc-backref" href="#toc-entry-2">Configuration</a></h2>
-<p>Esses relatórios são estruturados inicialmente com base no <strong>prefixo das
-contas</strong>. Se você estiver utilizando um plano de contas customizado, é
-importante revisar o campo <strong>prefixo da conta</strong> no cadastro do plano de
-contas para garantir que está alinhado com o que foi configurado no
-modelo de relatório.</p>
-<p>No entanto, essa configuração pode ser ajustada para utilizar <strong>outros
-métodos de identificação</strong> oferecidos pela ferramenta <strong>SIG</strong> (Sistema
-de Informação Gerencial), equivalente ao <strong>MIS</strong> (Management Information
-System) em inglês, implementada pelo módulo <strong>mis_builder</strong>.</p>
-<p>Para alterar um modelo, siga os passos abaixo:</p>
-<ol class="arabic simple">
-<li>Acesse <strong>Faturamento &gt; Configuração &gt; Relatórios SIG &gt; Modelos do
-Relatório SIG</strong>.</li>
-<li>Selecione o modelo que deseja editar e ajuste os critérios de
-identificação, incluindo o <strong>prefixo das contas</strong> ou outro método de
-identificação disponível.</li>
-<li>Certifique-se de que os <strong>prefixos configurados</strong> no modelo do
-relatório estejam <strong>alinhados</strong> com os prefixos do seu plano de
-contas.</li>
-</ol>
-<p>Para mais detalhes sobre como configurar, consulte a documentação do
-<strong>mis_builder</strong>.</p>
+<h1><a class="toc-backref" href="#toc-entry-2">Configuration</a></h1>
+<p>Os relatórios selecionam as contas pela <strong>classificação contábil
+brasileira</strong> (as etiquetas de conta do <tt class="docutils literal">l10n_br_coa</tt>), não pelo código
+da conta. Quem usa os planos <tt class="docutils literal">l10n_br_coa_generic</tt> ou
+<tt class="docutils literal">l10n_br_coa_simple</tt> não precisa configurar nada: eles já vêm
+classificados.</p>
+<p>Num <strong>plano de contas próprio</strong>, classifique as contas para que elas
+apareçam: vá em <strong>Faturamento &gt; Configuração &gt; Plano de Contas</strong>, abra a
+conta e preencha <strong>Etiquetas</strong> com a linha de relatório correspondente
+(por exemplo “Ativo / Circulante / Estoques” ou “Resultado / (-)
+Despesas Administrativas”).</p>
+<p>Toda conta de resultado leva <strong>duas</strong> etiquetas: a da sua linha na DRE e
+a etiqueta guarda-chuva “Resultado / Contas de Resultado (todas)”. É
+essa segunda que alimenta a linha “Resultado do Exercício” do Balanço,
+que é o que faz o ativo fechar com o passivo mais o patrimônio líquido.</p>
+<p>Conta sem etiqueta simplesmente não entra nos relatórios legais, que é o
+comportamento desejado para contas de controle interno.</p>
 </div>
 <div class="section" id="usage">
-<h2><a class="toc-backref" href="#toc-entry-3">Usage</a></h2>
-<ol class="arabic simple">
-<li>Acesse Faturamento &gt; Relatórios &gt; Relatórios SIG &gt; Relatórios SIG</li>
-<li>Crie um <strong>novo Relatório</strong>.</li>
-<li>Selecione um dos <strong>modelos de relatórios contabeis brasileiro</strong>.</li>
-<li>Na aba <strong>Layout</strong>, você pode desativar a <strong>expansão das contas</strong> para
-gerar um relatório mais resumido.</li>
-<li>Para selecionar os períodos, siga uma das opções abaixo:<ul>
-<li>Selecione diretamente o <strong>intervalo de datas</strong> ou o <strong>nome do
-período</strong> desejado para obter o relatório referente a esse período
-específico.</li>
-<li>Ative o <strong>Modo de Comparação</strong> e, na guia <strong>Colunas</strong>, defina
-quantas colunas deseja, com períodos diferentes. Esses períodos
-podem ser configurados com <strong>datas fixas</strong> ou períodos relativos.
-Por exemplo, defina “Tipo de período” como “Ano”, com
-“Deslocamento” = “0” e “Duração” = “1” para o ano corrente (N), e
-“Deslocamento” = “-1” para o ano anterior (N-1). Lembre-se de
-ajustar a <strong>data base</strong> do relatório para o ano a ser analisado.</li>
+<h1><a class="toc-backref" href="#toc-entry-3">Usage</a></h1>
+<p>O módulo já instala os relatórios prontos. Acesse <strong>Faturamento &gt;
+Relatórios &gt; Relatórios SIG</strong> e escolha um deles:</p>
+<ul class="simple">
+<li><strong>Balanço Patrimonial - exercício atual e anterior</strong>: a apresentação
+comparativa que a Lei 6.404/76 manda publicar (art. 176, § 1º), com a
+coluna de variação.</li>
+<li><strong>DRE - exercício atual e anterior</strong>: a mesma comparação, para o
+resultado.</li>
+<li><strong>DRE - mês e acumulado no exercício</strong>: o acompanhamento gerencial
+corrente, com o mês, o acumulado desde 1º de janeiro e as duas colunas
+equivalentes do exercício anterior.</li>
+<li><strong>DRE - trimestral</strong>: o trimestre em que se apura o IRPJ e a CSLL no
+lucro presumido e no lucro real trimestral (Lei 9.430/96, art. 1º),
+com o trimestre anterior e o mesmo trimestre do exercício passado.</li>
 </ul>
-</li>
-<li>Clique em <strong>Visualizar</strong>, <strong>Imprimir</strong> ou <strong>Exportar</strong> para calcular
-o relatório e executar a ação desejada.</li>
-<li>No modo de visualização, você pode clicar no <strong>valor</strong> das linhas
-detalhadas para visualizar os <strong>registros contábeis relacionados</strong>.</li>
-</ol>
+<p>Para ver outro período, mude a <strong>data base</strong> do relatório: todas as
+colunas se reposicionam juntas, porque são declaradas relativas a ela,
+não por data fixa.</p>
+<p>Depois clique em <strong>Visualizar</strong>, <strong>Imprimir</strong> ou <strong>Exportar</strong>. No modo
+de visualização, clicar no valor de uma linha detalhada abre os
+lançamentos que a compõem.</p>
+<div class="section" id="periodos">
+<h2><a class="toc-backref" href="#toc-entry-4">Períodos</a></h2>
+<p>O módulo instala três tipos de período (<strong>Faturamento &gt; Configuração &gt;
+Intervalos de Datas</strong>), que se geram sozinhos daí em diante:</p>
+<ul class="simple">
+<li><strong>Mês de competência</strong>, que é o período da apuração de ICMS, IPI, PIS
+e COFINS e da escrituração mensal do SPED;</li>
+<li><strong>Trimestre de apuração</strong>, o trimestre civil do IRPJ e da CSLL;</li>
+<li><strong>Exercício social</strong>, de um ano (Lei 6.404/76, art. 175).</li>
+</ul>
+</div>
+<div class="section" id="montar-um-relatorio-proprio">
+<h2><a class="toc-backref" href="#toc-entry-5">Montar um relatório próprio</a></h2>
+<p>Duplique um dos prontos e ajuste as colunas, ou crie um novo escolhendo
+o modelo BP ou DRE. Em <strong>Colunas</strong>, cada coluna pode ser uma data fixa
+ou um período relativo à data base: “Tipo de período” Ano com
+“Deslocamento” 0 é o exercício corrente, -1 o anterior. Marque
+<strong>Acumulado no ano</strong> para a coluna começar em 1º de janeiro.</p>
+<p>Uma ressalva do Balanço: a coluna precisa cobrir o exercício (o
+exercício inteiro ou um acumulado desde 1º de janeiro), porque o
+resultado do período é lido do movimento das contas de resultado. Numa
+coluna de mês isolado, o patrimônio líquido exibiria só o resultado
+daquele mês.</p>
+</div>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h2><a class="toc-backref" href="#toc-entry-4">Known issues / Roadmap</a></h2>
+<h1><a class="toc-backref" href="#toc-entry-6">Known issues / Roadmap</a></h1>
 <p>Fornecer modelos de <strong>Balanço Patrimonial (BP)</strong> e <strong>Demonstrativo de
 Resultados do Exercício (DRE)</strong> conforme a norma <strong>ITG 1000</strong>, com
 versões para:</p>
@@ -489,10 +488,37 @@ versões para:</p>
 </ul>
 </div>
 <div class="section" id="changelog">
-<h2><a class="toc-backref" href="#toc-entry-5">Changelog</a></h2>
+<h1><a class="toc-backref" href="#toc-entry-7">Changelog</a></h1>
+<div class="section" id="section-1">
+<h2><a class="toc-backref" href="#toc-entry-8">16.0.2.0.0</a></h2>
+<ul class="simple">
+<li>O Balanço e a DRE deixam de ser quatro modelos por prefixo de conta
+(um par por plano) e passam a ser <strong>um Balanço e uma DRE</strong> que
+selecionam as contas pela classificação contábil, valendo para
+qualquer plano, inclusive customizado. Até a versão 14.0 esse papel
+era dos tipos de conta brasileiros, que a versão 16.0 do Odoo
+eliminou.</li>
+<li>O Balanço ganha a linha <strong>Resultado do Exercício</strong>. Sem ela o
+resultado do período não aparecia em lugar nenhum e o balanço fechava
+com o ativo maior que o passivo mais o patrimônio líquido, pela
+diferença exata do lucro.</li>
+<li>Correções de seleção de conta que vinham desde a migração para a 16.0:
+os Lucros Acumulados apontavam para uma conta de compensação
+inexistente, o grupo de Lucros e Prejuízos Acumulados era contado duas
+vezes no patrimônio líquido, e as linhas de IRPJ e de CSLL apontavam
+para prefixos que não existem em nenhum dos dois planos.</li>
+<li>O módulo passa a instalar <strong>relatórios prontos</strong> e os <strong>períodos
+fiscais brasileiros</strong> (mês de competência, trimestre de apuração e
+exercício social), em vez de entregar só os modelos.</li>
+</ul>
+<p>Os modelos antigos (<tt class="docutils literal">balanco_patrimonial_generic</tt>,
+<tt class="docutils literal">balanco_patrimonial_simple</tt>, <tt class="docutils literal">dre_generic</tt> e <tt class="docutils literal">dre_simple</tt>) foram
+removidos. Relatórios montados sobre eles precisam ser refeitos sobre os
+novos.</p>
+</div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-6">Bug Tracker</a></h2>
+<h1><a class="toc-backref" href="#toc-entry-9">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-brazil/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -500,15 +526,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-7">Credits</a></h2>
+<h1><a class="toc-backref" href="#toc-entry-10">Credits</a></h1>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-8">Authors</a></h3>
+<h2><a class="toc-backref" href="#toc-entry-11">Authors</a></h2>
 <ul class="simple">
 <li>KMEE</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-9">Contributors</a></h3>
+<h2><a class="toc-backref" href="#toc-entry-12">Contributors</a></h2>
 <ul class="simple">
 <li>Luis Felipe Mileo &lt;<a class="reference external" href="mailto:mileo&#64;kmee.com.br">mileo&#64;kmee.com.br</a>&gt;</li>
 <li>Diego Paradeda &lt;<a class="reference external" href="mailto:diego.paradeda&#64;kmee.com.br">diego.paradeda&#64;kmee.com.br</a>&gt;</li>
@@ -516,7 +542,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h3>
+<h2><a class="toc-backref" href="#toc-entry-13">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
@@ -528,7 +554,6 @@ promote its widespread use.</p>
 <p><a class="reference external image-reference" href="https://github.com/mileo"><img alt="mileo" src="https://github.com/mileo.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/l10n-brazil/tree/16.0/l10n_br_mis_report">OCA/l10n-brazil</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
-</div>
 </div>
 </div>
 </div>

--- a/l10n_br_mis_report/tests/__init__.py
+++ b/l10n_br_mis_report/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_br_mis_report

--- a/l10n_br_mis_report/tests/test_l10n_br_mis_report.py
+++ b/l10n_br_mis_report/tests/test_l10n_br_mis_report.py
@@ -56,6 +56,20 @@ class TestL10nBrMisReport(AccountTestInvoicingCommon):
         cls.acc_capital = account(
             "TSTCP", "Capital Social", "equity", "account_tag_equity_capital"
         )
+        cls.acc_financeira = account(
+            "TSTDF",
+            "Despesas Financeiras",
+            "expense",
+            "account_tag_expenses_financial",
+            result=True,
+        )
+        cls.acc_irpj = account(
+            "TSTIR",
+            "Provisao para IRPJ",
+            "expense",
+            "account_tag_expense_irpj",
+            result=True,
+        )
 
         cls.journal = cls.company_data["default_journal_misc"]
         # the closed financial year the tests work on
@@ -134,6 +148,35 @@ class TestL10nBrMisReport(AccountTestInvoicingCommon):
         r = self._evaluate(self.dre)
         self.assertAlmostEqual(r["despesas_administrativas"], 400.0, places=2)
         self.assertAlmostEqual(r["resultado_liquido"], -400.0, places=2)
+
+    def test_result_of_the_year_matches_the_income_statement(self):
+        """The sheet and the income statement agree on the year result.
+
+        They are two paths to the same number: the balance sheet adds up the
+        accounts carrying the umbrella tag, while the income statement walks
+        down the cascade of its lines. They agree as long as the
+        classification is complete, and drift apart in silence the moment a
+        result account gets one tag and not the other. This test is what turns
+        that drift into a failure.
+
+        The entries deliberately touch four different lines of the cascade
+        (revenue, administrative expense, financial expense and income tax),
+        so the sum of the parts is a real check and not a tautology.
+        """
+        self._post([(self.acc_caixa, 2000.0, 0.0), (self.acc_receita, 0.0, 2000.0)])
+        self._post([(self.acc_despesa, 300.0, 0.0), (self.acc_caixa, 0.0, 300.0)])
+        self._post([(self.acc_financeira, 120.0, 0.0), (self.acc_caixa, 0.0, 120.0)])
+        self._post([(self.acc_irpj, 80.0, 0.0), (self.acc_caixa, 0.0, 80.0)])
+
+        bp = self._evaluate(self.bp)
+        dre = self._evaluate(self.dre)
+        # 2000 - 300 - 120 - 80
+        self.assertAlmostEqual(dre["resultado_liquido"], 1500.0, places=2)
+        self.assertAlmostEqual(
+            bp["resultado_exercicio"], dre["resultado_liquido"], places=2
+        )
+        # and the sheet still closes with that result inside equity
+        self.assertAlmostEqual(bp["total_ativo"], bp["total_passivo"], places=2)
 
 
 @tagged("post_install", "-at_install")

--- a/l10n_br_mis_report/tests/test_l10n_br_mis_report.py
+++ b/l10n_br_mis_report/tests/test_l10n_br_mis_report.py
@@ -1,0 +1,198 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestL10nBrMisReport(AccountTestInvoicingCommon):
+    """The reports are asserted against a posted entry, not against a fixture.
+
+    The defect these tests exist for was invisible to any check that only
+    looked at whether the report rendered: the balance sheet rendered fine and
+    was off by the whole result of the year, because it had no line for it.
+    """
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.company = cls.company_data["company"]
+        cls.bp = cls.env.ref("l10n_br_mis_report.bp")
+        cls.dre = cls.env.ref("l10n_br_mis_report.dre")
+
+        def account(code, name, account_type, tag, result=False):
+            # a result account also carries the umbrella tag, the same way
+            # the charts assign it: that is what the "Resultado do Exercicio"
+            # line of the balance sheet selects
+            tags = [(4, cls.env.ref("l10n_br_coa.%s" % tag).id)]
+            if result:
+                tags.append((4, cls.env.ref("l10n_br_coa.account_tag_result").id))
+            return cls.env["account.account"].create(
+                {
+                    "code": code,
+                    "name": name,
+                    "account_type": account_type,
+                    "company_id": cls.company.id,
+                    "tag_ids": tags,
+                }
+            )
+
+        cls.acc_caixa = account(
+            "TSTCX", "Caixa", "asset_cash", "account_tag_current_assets_cash"
+        )
+        cls.acc_receita = account(
+            "TSTRC", "Vendas", "income", "account_tag_revenue", result=True
+        )
+        cls.acc_despesa = account(
+            "TSTDA",
+            "Despesas Administrativas",
+            "expense",
+            "account_tag_admin_expenses",
+            result=True,
+        )
+        cls.acc_capital = account(
+            "TSTCP", "Capital Social", "equity", "account_tag_equity_capital"
+        )
+
+        cls.journal = cls.company_data["default_journal_misc"]
+        # the closed financial year the tests work on
+        cls.date_from = "2026-01-01"
+        cls.date_to = "2026-12-31"
+
+    @classmethod
+    def _post(cls, lines, date="2026-06-15"):
+        move = cls.env["account.move"].create(
+            {
+                "journal_id": cls.journal.id,
+                "company_id": cls.company.id,
+                "date": date,
+                "line_ids": [
+                    (0, 0, {"account_id": acc.id, "debit": d, "credit": c})
+                    for acc, d, c in lines
+                ],
+            }
+        )
+        move.action_post()
+        return move
+
+    def _evaluate(self, report):
+        aep = report._prepare_aep(self.company)
+        return report.with_company(self.company).evaluate(
+            aep, date_from=self.date_from, date_to=self.date_to
+        )
+
+    def test_balance_sheet_closes_with_the_result_of_the_year(self):
+        """Assets equal liabilities plus equity, with the year result between.
+
+        A sale of 1000 collected in cash leaves 1000 in assets and 1000 of
+        profit. Without the result line the equity side would read zero and
+        the sheet would be off by 1000, which is the defect: on a real
+        database the gap was the whole profit of the year.
+        """
+        self._post([(self.acc_caixa, 1000.0, 0.0), (self.acc_receita, 0.0, 1000.0)])
+        r = self._evaluate(self.bp)
+        self.assertAlmostEqual(r["total_ativo"], 1000.0, places=2)
+        self.assertAlmostEqual(r["resultado_exercicio"], 1000.0, places=2)
+        self.assertAlmostEqual(r["patrimonio_liquido"], 1000.0, places=2)
+        self.assertAlmostEqual(r["total_passivo"], 1000.0, places=2)
+        self.assertAlmostEqual(r["total_ativo"], r["total_passivo"], places=2)
+
+    def test_balance_sheet_closes_with_capital_and_expenses(self):
+        """The sheet also closes with paid-in capital and with a loss."""
+        self._post([(self.acc_caixa, 5000.0, 0.0), (self.acc_capital, 0.0, 5000.0)])
+        self._post([(self.acc_despesa, 800.0, 0.0), (self.acc_caixa, 0.0, 800.0)])
+        r = self._evaluate(self.bp)
+        # cash 5000 - 800 = 4200 of assets; capital 5000 and a loss of 800
+        self.assertAlmostEqual(r["total_ativo"], 4200.0, places=2)
+        self.assertAlmostEqual(r["capital_social"], 5000.0, places=2)
+        self.assertAlmostEqual(r["resultado_exercicio"], -800.0, places=2)
+        self.assertAlmostEqual(r["total_ativo"], r["total_passivo"], places=2)
+
+    def test_income_statement_follows_the_legal_order(self):
+        """The income statement walks down the steps article 187 lays out."""
+        self._post([(self.acc_caixa, 1000.0, 0.0), (self.acc_receita, 0.0, 1000.0)])
+        self._post([(self.acc_despesa, 250.0, 0.0), (self.acc_caixa, 0.0, 250.0)])
+        r = self._evaluate(self.dre)
+        self.assertAlmostEqual(r["receita_bruta"], 1000.0, places=2)
+        self.assertAlmostEqual(r["receita_liquida"], 1000.0, places=2)
+        self.assertAlmostEqual(r["lucro_bruto"], 1000.0, places=2)
+        self.assertAlmostEqual(r["despesas_administrativas"], 250.0, places=2)
+        self.assertAlmostEqual(r["resultado_operacional"], 750.0, places=2)
+        self.assertAlmostEqual(r["resultado_liquido"], 750.0, places=2)
+
+    def test_expenses_are_shown_positive_not_negative(self):
+        """An expense reads positive on its line and negative in the subtotal.
+
+        The sign convention is what separates a financial result added as
+        revenue from one added as a cost; without it the pre-tax result comes
+        out with the financial result inverted.
+        """
+        self._post([(self.acc_despesa, 400.0, 0.0), (self.acc_caixa, 0.0, 400.0)])
+        r = self._evaluate(self.dre)
+        self.assertAlmostEqual(r["despesas_administrativas"], 400.0, places=2)
+        self.assertAlmostEqual(r["resultado_liquido"], -400.0, places=2)
+
+
+@tagged("post_install", "-at_install")
+class TestL10nBrMisReportPeriods(AccountTestInvoicingCommon):
+    """The shipped periods have to yield the dates the law works with."""
+
+    def _period(self, xmlid):
+        return self.env.ref("l10n_br_mis_report.%s" % xmlid)
+
+    def test_quarter_is_the_civil_quarter_of_the_assessment(self):
+        """The income tax quarter is the civil one, not a three month window.
+
+        With the base date anywhere inside the quarter, the column has to
+        cover the whole quarter. A relative three month window would only
+        coincide with it when the base date fell on the last month.
+        """
+        instance = self._period("instance_dre_trimestral")
+        instance.date = fields.Date.to_date("2026-05-20")  # mid second quarter
+        col = instance.period_ids.filtered(lambda p: p.offset == 0)
+        self.assertEqual(str(col.date_from), "2026-04-01")
+        self.assertEqual(str(col.date_to), "2026-06-30")
+
+    def test_previous_quarter_and_same_quarter_last_year(self):
+        instance = self._period("instance_dre_trimestral")
+        instance.date = fields.Date.to_date("2026-05-20")
+        anterior = instance.period_ids.filtered(lambda p: p.offset == -1)
+        self.assertEqual(str(anterior.date_from), "2026-01-01")
+        self.assertEqual(str(anterior.date_to), "2026-03-31")
+        ano_anterior = instance.period_ids.filtered(lambda p: p.offset == -4)
+        self.assertEqual(str(ano_anterior.date_from), "2025-04-01")
+        self.assertEqual(str(ano_anterior.date_to), "2025-06-30")
+
+    def test_year_to_date_column_starts_on_january_first(self):
+        """The accumulated column runs from January 1st to the base month end."""
+        instance = self._period("instance_dre_mensal")
+        instance.date = fields.Date.to_date("2026-05-20")
+        acumulado = instance.period_ids.filtered(lambda p: p.is_ytd and p.offset == 0)
+        self.assertEqual(str(acumulado.date_from), "2026-01-01")
+        self.assertEqual(str(acumulado.date_to), "2026-05-31")
+        mes = instance.period_ids.filtered(lambda p: not p.is_ytd and p.offset == 0)
+        self.assertEqual(str(mes.date_from), "2026-05-01")
+        self.assertEqual(str(mes.date_to), "2026-05-31")
+
+    def test_balance_sheet_columns_cover_whole_exercises(self):
+        """The comparative sheet compares whole financial years.
+
+        The column has to cover the year because the period result is read
+        from the movement of the result accounts: on a shorter range the
+        equity side would show only part of the profit.
+        """
+        instance = self._period("instance_bp_exercicio")
+        instance.date = fields.Date.to_date("2026-05-20")
+        atual = instance.period_ids.filtered(
+            lambda p: p.source == "actuals" and p.offset == 0
+        )
+        self.assertEqual(str(atual.date_from), "2026-01-01")
+        self.assertEqual(str(atual.date_to), "2026-12-31")
+        anterior = instance.period_ids.filtered(
+            lambda p: p.source == "actuals" and p.offset == -1
+        )
+        self.assertEqual(str(anterior.date_from), "2025-01-01")
+        self.assertEqual(str(anterior.date_to), "2025-12-31")


### PR DESCRIPTION
Fase 1 do PRD das demonstrações contábeis completas
(`l10n-brazil/planejamento/PRD_MIS_REPORT_DEMONSTRACOES_SA.md`), aberto aqui no
fork para revisão interna antes de ir para a OCA.

Empilha na branch `16.0-imp-l10n_br_coa-classificacao` (PR OCA #4944), que é a
base deste diff.

## O que entra

20 etiquetas de classificação, numa segunda dimensão ortogonal à do Balanço e da
DRE: a conta continua sendo "Ativo / Circulante / Estoques" e passa a declarar
também a que atividade do fluxo de caixa pertence.

- **Fluxo de caixa** (CPC 03): operacional, investimento, financiamento, caixa e
  equivalentes, e "não afeta o caixa";
- **Ajustes ao resultado** que a DFC indireta soma de volta: depreciação,
  provisões, equivalência patrimonial, resultado na baixa de ativo;
- **Resultado abrangente** (CPC 26), para a DRA e para a coluna de ajustes de
  avaliação patrimonial da DMPL;
- **Valor adicionado** (CPC 09): insumos, pessoal, impostos, capitais de
  terceiros e próprios, recebido em transferência.

As 626 contas dos dois planos já vêm classificadas.

## Pontos para a revisão

1. **A quinta etiqueta de fluxo de caixa ("não afeta o caixa")** foi decisão
   minha e não estava no PRD. Ela torna a classificação total: sem ela, conta
   patrimonial sem etiqueta seria ambígua entre "esqueceram" e "não afeta o
   caixa mesmo". Com ela, ausência é sempre erro, e o teste consegue exigir
   exatamente uma atividade por conta.

2. **A conta de transferência de liquidez.** Ela não é declarada pelo plano: o
   core a cria ao carregar o `account.chart.template`. Declará-la no CSV NÃO
   substitui a do core, faz o core criar uma segunda ao lado (ele procura o
   primeiro código livre e desiste do que encontra ocupado). Por isso o ajuste
   ficou em `_prepare_transfer_account_template`, e as etiquetas passaram a ser
   carregadas antes do plano no manifesto. Sem isso ela nascia órfã e ficava de
   fora dos relatórios, e transferência entre bancos em trânsito no fim do
   período viraria diferença sem explicação.

3. **A classificação da DVA usa heurística por nome** onde o prefixo reúne
   despesas de naturezas diferentes (salário vira pessoal, aluguel vira capital
   de terceiros, IPTU vira imposto). Vale conferir por amostragem se alguma
   conta ficou na linha errada. O CPC 09 pede a mão de obra do custo de produção
   em "pessoal" e não em "insumos", o que já está tratado.

4. **Segregações que o plano ainda não permite**: encargos sociais reúnem FGTS
   (pessoal) e INSS patronal (impostos), e o CPC 09 os quer separados. Fica para
   a fase da DVA, junto com as contas novas no plano genérico.

## Testes

Quatro, todos sobre os planos instalados:

- toda conta carrega uma linha de relatório;
- toda conta patrimonial declara exatamente uma atividade de fluxo de caixa;
- **nenhuma conta de resultado declara atividade** (é a regra que evita contar o
  mesmo valor duas vezes na DFC);
- toda conta de custo e despesa diz como distribui o valor adicionado.
