### PR TITLE
[16.0][ADD] l10n_br_mis_report_sa: DMPL e DLPA

### DIFF
--- a/l10n_br_mis_report_sa/README.rst
+++ b/l10n_br_mis_report_sa/README.rst
@@ -41,6 +41,12 @@ Como as demais demonstrações do guarda-chuva, as contas são selecionadas
 pela classificação contábil, então o mesmo relatório serve qualquer
 plano de contas.
 
+Nesta versão, além da DFC: a **Demonstração das Mutações do Patrimônio
+Líquido** (CPC 26 R1) e a **Demonstração dos Lucros ou Prejuízos
+Acumulados** (art. 186 da Lei 6.404/76). Publicar a DMPL dispensa a
+DLPA, por força do art. 186, § 2º, e por isso as duas vêm juntas: quem
+publica a segunda não precisa da primeira.
+
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
    Only for development or testing purpose, do not use in production.

--- a/l10n_br_mis_report_sa/__manifest__.py
+++ b/l10n_br_mis_report_sa/__manifest__.py
@@ -17,6 +17,8 @@
     ],
     "data": [
         "data/mis_report_dfc.xml",
+        "data/mis_report_dmpl.xml",
+        "data/mis_report_dlpa.xml",
         "data/mis_report_instance.xml",
     ],
 }

--- a/l10n_br_mis_report_sa/data/mis_report_dlpa.xml
+++ b/l10n_br_mis_report_sa/data/mis_report_dlpa.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 KMEE
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!--
+      Demonstração dos Lucros ou Prejuízos Acumulados, na forma do art. 186 da
+      Lei 6.404/76. Ela é a coluna de lucros acumulados da DMPL apresentada em
+      lista, e o art. 186, § 2º dispensa quem publica a DMPL de publicá-la.
+      Existe aqui para quem opta por não publicar a demonstração das mutações.
+
+      A separação entre transferência para reservas e dividendo é inferida do
+      movimento das reservas, e não da contrapartida do lançamento: o que
+      entrou nas reservas de lucros no período saiu daqui. O que sobra do
+      débito é destinação aos sócios. As duas linhas somadas reproduzem a
+      variação da conta de lucros acumulados, então o total fecha mesmo quando
+      a inferência erra a divisão entre as duas.
+    -->
+    <record id="dlpa" model="mis.report">
+        <field
+            name="name"
+        >DLPA - Demonstração dos Lucros ou Prejuízos Acumulados</field>
+        <field
+            name="description"
+        >Demonstração dos Lucros ou Prejuízos Acumulados</field>
+        <field name="move_lines_source" ref="account.model_account_move_line" />
+    </record>
+
+    <record id="dlpa_subreport_dre" model="mis.report.subreport">
+        <field name="name">dre</field>
+        <field name="report_id" ref="dlpa" />
+        <field name="subreport_id" ref="l10n_br_mis_report.dre" />
+    </record>
+
+    <record id="dlpa_saldo_inicial" model="mis.report.kpi">
+        <field name="sequence">10</field>
+        <field name="report_id" ref="dlpa" />
+        <field name="description">Saldo no início do período</field>
+        <field name="name">saldo_inicial</field>
+        <field name="expression">-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)] - bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_losses').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dlpa_resultado" model="mis.report.kpi">
+        <field name="sequence">20</field>
+        <field name="report_id" ref="dlpa" />
+        <field name="description">(+/-) Resultado do exercício</field>
+        <field name="name">resultado</field>
+        <field name="expression">dre.resultado_liquido</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dlpa_disposicao" model="mis.report.kpi">
+        <field name="sequence">30</field>
+        <field name="report_id" ref="dlpa" />
+        <field name="description">= Saldo à disposição</field>
+        <field name="name">disposicao</field>
+        <field name="expression">saldo_inicial+resultado</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dlpa_reservas" model="mis.report.kpi">
+        <field name="sequence">40</field>
+        <field name="report_id" ref="dlpa" />
+        <field name="description">(-) Transferências para reservas</field>
+        <field name="name">reservas</field>
+        <field name="expression">+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_profit_reserve').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dlpa_dividendos" model="mis.report.kpi">
+        <field name="sequence">50</field>
+        <field name="report_id" ref="dlpa" />
+        <field name="description">(-) Dividendos, juros sobre capital próprio e demais destinações</field>
+        <field name="name">dividendos</field>
+        <field name="expression">-deb[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)] + crd[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)] - bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_profit_reserve').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dlpa_saldo_final" model="mis.report.kpi">
+        <field name="sequence">60</field>
+        <field name="report_id" ref="dlpa" />
+        <field name="description">= Saldo no fim do período</field>
+        <field name="name">saldo_final</field>
+        <field name="expression">disposicao+reservas+dividendos</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+</odoo>

--- a/l10n_br_mis_report_sa/data/mis_report_dmpl.xml
+++ b/l10n_br_mis_report_sa/data/mis_report_dmpl.xml
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 KMEE
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!--
+      Demonstração das Mutações do Patrimônio Líquido (CPC 26 R1).
+
+      Ela é a única demonstração deste guarda-chuva que não é uma lista de
+      linhas: é uma MATRIZ. As colunas são os componentes do patrimônio
+      líquido e as linhas são os eventos que o movimentaram no período. O
+      mis_builder produz isso com `mis.report.subkpi`: cada subkpi vira uma
+      coluna, e cada linha declara uma expressão por coluna.
+
+      Consequência: as colunas já estão ocupadas pelos componentes, então a
+      comparação com o exercício anterior é feita gerando a demonstração duas
+      vezes, e não lado a lado.
+
+      Publicar a DMPL satisfaz também o inciso II do art. 176 da Lei 6.404/76,
+      porque o art. 186, § 2º permite incluir nela a demonstração dos lucros ou
+      prejuízos acumulados.
+
+      CONVENÇÃO DE SINAL. O patrimônio líquido é credor, e no Odoo saldo credor
+      é negativo, então todo saldo entra invertido para ser exibido positivo.
+      Aumento de capital lê os CRÉDITOS do período e redução lê os DÉBITOS, o
+      que separa os dois eventos sem exigir uma conta para cada um.
+
+      O RESULTADO DO EXERCÍCIO vem da DRE, por subrelatório, e não do saldo da
+      conta de lucros acumulados: o Odoo não escritura o encerramento do
+      exercício, mantém o resultado nas contas de resultado e o apresenta à
+      parte. Por isso o saldo final da coluna de lucros acumulados soma o
+      resultado ao saldo contábil, exatamente como o Balanço faz, e a coluna
+      Total reproduz o patrimônio líquido do Balanço na mesma data.
+    -->
+    <record id="dmpl" model="mis.report">
+        <field
+            name="name"
+        >DMPL - Demonstração das Mutações do Patrimônio Líquido</field>
+        <field
+            name="description"
+        >Demonstração das Mutações do Patrimônio Líquido</field>
+        <field name="move_lines_source" ref="account.model_account_move_line" />
+    </record>
+
+    <record id="dmpl_subreport_dre" model="mis.report.subreport">
+        <field name="name">dre</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="subreport_id" ref="l10n_br_mis_report.dre" />
+    </record>
+
+    <record id="dmpl_col_capital" model="mis.report.subkpi">
+        <field name="sequence">10</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="name">capital</field>
+        <field name="description">Capital Social</field>
+    </record>
+
+    <record id="dmpl_col_reservas_capital" model="mis.report.subkpi">
+        <field name="sequence">20</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="name">reservas_capital</field>
+        <field name="description">Reservas de Capital</field>
+    </record>
+
+    <record id="dmpl_col_reservas_lucros" model="mis.report.subkpi">
+        <field name="sequence">30</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="name">reservas_lucros</field>
+        <field name="description">Reservas de Lucros</field>
+    </record>
+
+    <record id="dmpl_col_lucros" model="mis.report.subkpi">
+        <field name="sequence">40</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="name">lucros</field>
+        <field name="description">Lucros ou Prejuízos Acumulados</field>
+    </record>
+
+    <record id="dmpl_col_ajustes" model="mis.report.subkpi">
+        <field name="sequence">50</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="name">ajustes</field>
+        <field name="description">Ajustes de Avaliação Patrimonial</field>
+    </record>
+
+    <record id="dmpl_col_total" model="mis.report.subkpi">
+        <field name="sequence">60</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="name">total</field>
+        <field name="description">Total</field>
+    </record>
+
+    <record id="dmpl_saldo_inicial" model="mis.report.kpi">
+        <field name="sequence">10</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="description">Saldo no início do período</field>
+        <field name="name">saldo_inicial</field>
+        <field name="multi" eval="True" />
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+        <field name="expression_ids" eval="[(5, 0, 0)]" />
+    </record>
+
+    <record id="dmpl_saldo_inicial_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_inicial" />
+        <field name="subkpi_id" ref="dmpl_col_capital" />
+        <field name="name">-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital').id)]</field>
+    </record>
+    <record id="dmpl_saldo_inicial_reservas_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_inicial" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_capital" />
+        <field name="name">-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital_reserve').id)]</field>
+    </record>
+    <record id="dmpl_saldo_inicial_reservas_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_inicial" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_lucros" />
+        <field name="name">-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_profit_reserve').id)]</field>
+    </record>
+    <record id="dmpl_saldo_inicial_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_inicial" />
+        <field name="subkpi_id" ref="dmpl_col_lucros" />
+        <field name="name">-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)] - bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_losses').id)]</field>
+    </record>
+    <record id="dmpl_saldo_inicial_ajustes" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_inicial" />
+        <field name="subkpi_id" ref="dmpl_col_ajustes" />
+        <field name="name">-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_valuation_adjustment').id)]</field>
+    </record>
+    <record id="dmpl_saldo_inicial_total" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_inicial" />
+        <field name="subkpi_id" ref="dmpl_col_total" />
+        <field name="name">(-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital').id)]) + (-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital_reserve').id)]) + (-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_profit_reserve').id)]) + (-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)] - bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_losses').id)]) + (-bali[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_valuation_adjustment').id)])</field>
+    </record>
+
+    <record id="dmpl_aumento_capital" model="mis.report.kpi">
+        <field name="sequence">20</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="description">Aumento de capital</field>
+        <field name="name">aumento_capital</field>
+        <field name="multi" eval="True" />
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="expression_ids" eval="[(5, 0, 0)]" />
+    </record>
+
+    <record id="dmpl_aumento_capital_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_aumento_capital" />
+        <field name="subkpi_id" ref="dmpl_col_capital" />
+        <field name="name">+crd[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital').id)]</field>
+    </record>
+    <record id="dmpl_aumento_capital_reservas_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_aumento_capital" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_capital" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_aumento_capital_reservas_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_aumento_capital" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_lucros" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_aumento_capital_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_aumento_capital" />
+        <field name="subkpi_id" ref="dmpl_col_lucros" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_aumento_capital_ajustes" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_aumento_capital" />
+        <field name="subkpi_id" ref="dmpl_col_ajustes" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_aumento_capital_total" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_aumento_capital" />
+        <field name="subkpi_id" ref="dmpl_col_total" />
+        <field name="name">(+crd[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital').id)]) + (0.0) + (0.0) + (0.0) + (0.0)</field>
+    </record>
+
+    <record id="dmpl_reducao_capital" model="mis.report.kpi">
+        <field name="sequence">30</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="description">(-) Redução de capital</field>
+        <field name="name">reducao_capital</field>
+        <field name="multi" eval="True" />
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="expression_ids" eval="[(5, 0, 0)]" />
+    </record>
+
+    <record id="dmpl_reducao_capital_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reducao_capital" />
+        <field name="subkpi_id" ref="dmpl_col_capital" />
+        <field name="name">-deb[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital').id)]</field>
+    </record>
+    <record id="dmpl_reducao_capital_reservas_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reducao_capital" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_capital" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_reducao_capital_reservas_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reducao_capital" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_lucros" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_reducao_capital_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reducao_capital" />
+        <field name="subkpi_id" ref="dmpl_col_lucros" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_reducao_capital_ajustes" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reducao_capital" />
+        <field name="subkpi_id" ref="dmpl_col_ajustes" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_reducao_capital_total" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reducao_capital" />
+        <field name="subkpi_id" ref="dmpl_col_total" />
+        <field name="name">(-deb[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital').id)]) + (0.0) + (0.0) + (0.0) + (0.0)</field>
+    </record>
+
+    <record id="dmpl_resultado" model="mis.report.kpi">
+        <field name="sequence">40</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="description">Resultado do exercício</field>
+        <field name="name">resultado</field>
+        <field name="multi" eval="True" />
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="expression_ids" eval="[(5, 0, 0)]" />
+    </record>
+
+    <record id="dmpl_resultado_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_resultado" />
+        <field name="subkpi_id" ref="dmpl_col_capital" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_resultado_reservas_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_resultado" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_capital" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_resultado_reservas_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_resultado" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_lucros" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_resultado_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_resultado" />
+        <field name="subkpi_id" ref="dmpl_col_lucros" />
+        <field name="name">dre.resultado_liquido</field>
+    </record>
+    <record id="dmpl_resultado_ajustes" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_resultado" />
+        <field name="subkpi_id" ref="dmpl_col_ajustes" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_resultado_total" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_resultado" />
+        <field name="subkpi_id" ref="dmpl_col_total" />
+        <field name="name">(0.0) + (0.0) + (0.0) + (dre.resultado_liquido) + (0.0)</field>
+    </record>
+
+    <record id="dmpl_abrangente" model="mis.report.kpi">
+        <field name="sequence">50</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="description">Outros resultados abrangentes</field>
+        <field name="name">abrangente</field>
+        <field name="multi" eval="True" />
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="expression_ids" eval="[(5, 0, 0)]" />
+    </record>
+
+    <record id="dmpl_abrangente_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_abrangente" />
+        <field name="subkpi_id" ref="dmpl_col_capital" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_abrangente_reservas_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_abrangente" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_capital" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_abrangente_reservas_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_abrangente" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_lucros" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_abrangente_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_abrangente" />
+        <field name="subkpi_id" ref="dmpl_col_lucros" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_abrangente_ajustes" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_abrangente" />
+        <field name="subkpi_id" ref="dmpl_col_ajustes" />
+        <field name="name">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_valuation_adjustment').id)]</field>
+    </record>
+    <record id="dmpl_abrangente_total" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_abrangente" />
+        <field name="subkpi_id" ref="dmpl_col_total" />
+        <field name="name">(0.0) + (0.0) + (0.0) + (0.0) + (-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_valuation_adjustment').id)])</field>
+    </record>
+
+    <record id="dmpl_reservas_movimento" model="mis.report.kpi">
+        <field name="sequence">60</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="description">Constituição e realização de reservas</field>
+        <field name="name">reservas_movimento</field>
+        <field name="multi" eval="True" />
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="expression_ids" eval="[(5, 0, 0)]" />
+    </record>
+
+    <record id="dmpl_reservas_movimento_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reservas_movimento" />
+        <field name="subkpi_id" ref="dmpl_col_capital" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_reservas_movimento_reservas_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reservas_movimento" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_capital" />
+        <field name="name">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital_reserve').id)]</field>
+    </record>
+    <record id="dmpl_reservas_movimento_reservas_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reservas_movimento" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_lucros" />
+        <field name="name">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_profit_reserve').id)]</field>
+    </record>
+    <record id="dmpl_reservas_movimento_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reservas_movimento" />
+        <field name="subkpi_id" ref="dmpl_col_lucros" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_reservas_movimento_ajustes" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reservas_movimento" />
+        <field name="subkpi_id" ref="dmpl_col_ajustes" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_reservas_movimento_total" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_reservas_movimento" />
+        <field name="subkpi_id" ref="dmpl_col_total" />
+        <field name="name">(0.0) + (-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital_reserve').id)]) + (-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_profit_reserve').id)]) + (0.0) + (0.0)</field>
+    </record>
+
+    <record id="dmpl_destinacao" model="mis.report.kpi">
+        <field name="sequence">70</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="description">Destinação do resultado, dividendos e juros sobre capital próprio</field>
+        <field name="name">destinacao</field>
+        <field name="multi" eval="True" />
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="expression_ids" eval="[(5, 0, 0)]" />
+    </record>
+
+    <record id="dmpl_destinacao_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_destinacao" />
+        <field name="subkpi_id" ref="dmpl_col_capital" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_destinacao_reservas_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_destinacao" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_capital" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_destinacao_reservas_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_destinacao" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_lucros" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_destinacao_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_destinacao" />
+        <field name="subkpi_id" ref="dmpl_col_lucros" />
+        <field name="name">-deb[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)] + crd[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)]</field>
+    </record>
+    <record id="dmpl_destinacao_ajustes" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_destinacao" />
+        <field name="subkpi_id" ref="dmpl_col_ajustes" />
+        <field name="name">0.0</field>
+    </record>
+    <record id="dmpl_destinacao_total" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_destinacao" />
+        <field name="subkpi_id" ref="dmpl_col_total" />
+        <field name="name">(0.0) + (0.0) + (0.0) + (-deb[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)] + crd[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)]) + (0.0)</field>
+    </record>
+
+    <record id="dmpl_saldo_final" model="mis.report.kpi">
+        <field name="sequence">90</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="description">Saldo no fim do período</field>
+        <field name="name">saldo_final</field>
+        <field name="multi" eval="True" />
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+        <field name="expression_ids" eval="[(5, 0, 0)]" />
+    </record>
+
+    <record id="dmpl_saldo_final_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_final" />
+        <field name="subkpi_id" ref="dmpl_col_capital" />
+        <field name="name">-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital').id)]</field>
+    </record>
+    <record id="dmpl_saldo_final_reservas_capital" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_final" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_capital" />
+        <field name="name">-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital_reserve').id)]</field>
+    </record>
+    <record id="dmpl_saldo_final_reservas_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_final" />
+        <field name="subkpi_id" ref="dmpl_col_reservas_lucros" />
+        <field name="name">-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_profit_reserve').id)]</field>
+    </record>
+    <record id="dmpl_saldo_final_lucros" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_final" />
+        <field name="subkpi_id" ref="dmpl_col_lucros" />
+        <field name="name">-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)] - bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_losses').id)] + dre.resultado_liquido</field>
+    </record>
+    <record id="dmpl_saldo_final_ajustes" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_final" />
+        <field name="subkpi_id" ref="dmpl_col_ajustes" />
+        <field name="name">-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_valuation_adjustment').id)]</field>
+    </record>
+    <record id="dmpl_saldo_final_total" model="mis.report.kpi.expression">
+        <field name="kpi_id" ref="dmpl_saldo_final" />
+        <field name="subkpi_id" ref="dmpl_col_total" />
+        <field name="name">(-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital').id)]) + (-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_capital_reserve').id)]) + (-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_profit_reserve').id)]) + (-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_profits').id)] - bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_accumulated_losses').id)] + dre.resultado_liquido) + (-bale[('tag_ids', '=', ref('l10n_br_coa.account_tag_equity_valuation_adjustment').id)])</field>
+    </record>
+
+</odoo>

--- a/l10n_br_mis_report_sa/data/mis_report_instance.xml
+++ b/l10n_br_mis_report_sa/data/mis_report_instance.xml
@@ -38,4 +38,62 @@
         <field name="offset">0</field>
         <field name="duration">1</field>
     </record>
+
+    <!--
+      A DMPL roda numa coluna de período só: as colunas da matriz já estão
+      ocupadas pelos componentes do patrimônio líquido. Comparar com o
+      exercício anterior é gerar a demonstração de novo com outra data base.
+    -->
+    <record id="instance_dmpl" model="mis.report.instance">
+        <field name="name">DMPL - exercício atual</field>
+        <field name="report_id" ref="dmpl" />
+        <field name="sequence">60</field>
+        <field name="company_id" eval="False" />
+        <field name="target_move">posted</field>
+        <field name="comparison_mode" eval="True" />
+        <field name="display_columns_description" eval="True" />
+    </record>
+
+    <record id="instance_dmpl_atual" model="mis.report.instance.period">
+        <field name="name">Exercício atual</field>
+        <field name="report_instance_id" ref="instance_dmpl" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">10</field>
+        <field name="type">y</field>
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dlpa" model="mis.report.instance">
+        <field name="name">DLPA - exercício atual e anterior</field>
+        <field name="report_id" ref="dlpa" />
+        <field name="sequence">70</field>
+        <field name="company_id" eval="False" />
+        <field name="target_move">posted</field>
+        <field name="comparison_mode" eval="True" />
+        <field name="display_columns_description" eval="True" />
+    </record>
+
+    <record id="instance_dlpa_ant" model="mis.report.instance.period">
+        <field name="name">Exercício anterior</field>
+        <field name="report_instance_id" ref="instance_dlpa" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">10</field>
+        <field name="type">y</field>
+        <field name="offset">-1</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dlpa_atual" model="mis.report.instance.period">
+        <field name="name">Exercício atual</field>
+        <field name="report_instance_id" ref="instance_dlpa" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">20</field>
+        <field name="type">y</field>
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+    </record>
 </odoo>

--- a/l10n_br_mis_report_sa/readme/DESCRIPTION.md
+++ b/l10n_br_mis_report_sa/readme/DESCRIPTION.md
@@ -9,3 +9,8 @@ Em preparação, na ordem: DMPL e DLPA, depois DRA e DVA.
 
 Como as demais demonstrações do guarda-chuva, as contas são selecionadas pela
 classificação contábil, então o mesmo relatório serve qualquer plano de contas.
+
+Nesta versão, além da DFC: a **Demonstração das Mutações do Patrimônio Líquido**
+(CPC 26 R1) e a **Demonstração dos Lucros ou Prejuízos Acumulados** (art. 186 da
+Lei 6.404/76). Publicar a DMPL dispensa a DLPA, por força do art. 186, § 2º, e
+por isso as duas vêm juntas: quem publica a segunda não precisa da primeira.

--- a/l10n_br_mis_report_sa/static/description/index.html
+++ b/l10n_br_mis_report_sa/static/description/index.html
@@ -379,6 +379,11 @@ indireto (CPC 03 R2), exigida pelo art. 176, inciso IV.</p>
 <p>Como as demais demonstrações do guarda-chuva, as contas são selecionadas
 pela classificação contábil, então o mesmo relatório serve qualquer
 plano de contas.</p>
+<p>Nesta versão, além da DFC: a <strong>Demonstração das Mutações do Patrimônio
+Líquido</strong> (CPC 26 R1) e a <strong>Demonstração dos Lucros ou Prejuízos
+Acumulados</strong> (art. 186 da Lei 6.404/76). Publicar a DMPL dispensa a
+DLPA, por força do art. 186, § 2º, e por isso as duas vêm juntas: quem
+publica a segunda não precisa da primeira.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.

--- a/l10n_br_mis_report_sa/tests/__init__.py
+++ b/l10n_br_mis_report_sa/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_dfc
+from . import test_dmpl

--- a/l10n_br_mis_report_sa/tests/test_dmpl.py
+++ b/l10n_br_mis_report_sa/tests/test_dmpl.py
@@ -1,0 +1,205 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+"""The statement of changes in equity has to tie, column by column.
+
+Opening balance plus what moved has to equal the closing balance, on every
+component, and the Total column has to reproduce the equity the balance sheet
+shows on the same date. A matrix that renders and does not tie is wrong.
+"""
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+class EquityCommon(AccountTestInvoicingCommon):
+    """Cenário compartilhado pela DMPL e pela DLPA.
+
+    As duas leem os mesmos movimentos, e o que as faria divergir é justamente
+    montar cenários separados para cada uma.
+    """
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.company = cls.company_data["company"]
+        cls.journal = cls.company_data["default_journal_misc"]
+        cls.dmpl = cls.env.ref("l10n_br_mis_report_sa.dmpl")
+        cls.bp = cls.env.ref("l10n_br_mis_report.bp")
+
+        def account(code, name, account_type, *tags):
+            return cls.env["account.account"].create(
+                {
+                    "code": code,
+                    "name": name,
+                    "account_type": account_type,
+                    "company_id": cls.company.id,
+                    "tag_ids": [
+                        (4, cls.env.ref("l10n_br_coa.%s" % tag).id) for tag in tags
+                    ],
+                }
+            )
+
+        cls.caixa = account(
+            "DMP10", "Caixa", "asset_cash",
+            "account_tag_current_assets_cash",
+            "account_tag_cash_and_equivalents",
+        )
+        cls.capital = account(
+            "DMP24", "Capital Social", "equity",
+            "account_tag_equity_capital", "account_tag_cash_flow_financing",
+        )
+        cls.reserva = account(
+            "DMP25", "Reserva Legal", "equity",
+            "account_tag_equity_profit_reserve", "account_tag_cash_flow_non_cash",
+        )
+        cls.lucros = account(
+            "DMP26", "Lucros Acumulados", "equity",
+            "account_tag_equity_accumulated_profits",
+            "account_tag_cash_flow_non_cash",
+        )
+        cls.dividendos = account(
+            "DMP21", "Dividendos a Pagar", "liability_current",
+            "account_tag_current_liabilities_payable",
+            "account_tag_cash_flow_financing",
+        )
+        cls.receita = account(
+            "DMP90", "Vendas", "income",
+            "account_tag_revenue", "account_tag_result",
+        )
+
+        cls.date_from = "2026-01-01"
+        cls.date_to = "2026-12-31"
+
+    @classmethod
+    def _post(cls, lines, date="2026-06-15"):
+        move = cls.env["account.move"].create(
+            {
+                "journal_id": cls.journal.id,
+                "company_id": cls.company.id,
+                "date": date,
+                "line_ids": [
+                    (0, 0, {"account_id": acc.id, "debit": d, "credit": c})
+                    for acc, d, c in lines
+                ],
+            }
+        )
+        move.action_post()
+        return move
+
+    def _evaluate(self, report):
+        aep = report._prepare_aep(self.company)
+        return report.with_company(self.company).evaluate(
+            aep, date_from=self.date_from, date_to=self.date_to
+        )
+
+    def _column(self, values, kpi, index):
+        """A matrix KPI comes back as one value per column, in order."""
+        return values[kpi][index]
+
+
+@tagged("post_install", "-at_install")
+class TestDmpl(EquityCommon):
+    def test_capital_paid_in_shows_on_its_own_column(self):
+        """Paying in capital moves the capital column and nothing else."""
+        self._post([(self.caixa, 20000.0, 0.0), (self.capital, 0.0, 20000.0)])
+        r = self._evaluate(self.dmpl)
+        # column order: capital, reservas de capital, reservas de lucros,
+        # lucros acumulados, ajustes, total
+        self.assertAlmostEqual(self._column(r, "aumento_capital", 0), 20000.0, places=2)
+        self.assertAlmostEqual(self._column(r, "saldo_final", 0), 20000.0, places=2)
+        self.assertAlmostEqual(self._column(r, "saldo_final", 5), 20000.0, places=2)
+
+    def test_each_column_ties_from_opening_to_closing(self):
+        """Opening plus movements equals closing, on every component."""
+        self._post([(self.caixa, 20000.0, 0.0), (self.capital, 0.0, 20000.0)])
+        self._post([(self.caixa, 7000.0, 0.0), (self.receita, 0.0, 7000.0)])
+        self._post([(self.lucros, 1200.0, 0.0), (self.dividendos, 0.0, 1200.0)])
+        self._post([(self.lucros, 800.0, 0.0), (self.reserva, 0.0, 800.0)])
+
+        r = self._evaluate(self.dmpl)
+        movimento_por_coluna = (
+            "aumento_capital",
+            "reducao_capital",
+            "resultado",
+            "abrangente",
+            "reservas_movimento",
+            "destinacao",
+        )
+        for index in range(6):
+            inicial = self._column(r, "saldo_inicial", index)
+            final = self._column(r, "saldo_final", index)
+            movimentos = sum(
+                self._column(r, kpi, index) for kpi in movimento_por_coluna
+            )
+            self.assertAlmostEqual(
+                inicial + movimentos,
+                final,
+                places=2,
+                msg="a coluna %s não fecha: %.2f de saldo inicial mais %.2f de "
+                "movimento não dá os %.2f do saldo final"
+                % (index, inicial, movimentos, final),
+            )
+
+    def test_the_total_column_reproduces_the_equity_of_the_balance_sheet(self):
+        """The Total column is the equity the balance sheet shows.
+
+        They are two statements reading the same thing, and a difference means
+        one of them is leaving a component out.
+        """
+        self._post([(self.caixa, 20000.0, 0.0), (self.capital, 0.0, 20000.0)])
+        self._post([(self.caixa, 7000.0, 0.0), (self.receita, 0.0, 7000.0)])
+        self._post([(self.lucros, 1200.0, 0.0), (self.dividendos, 0.0, 1200.0)])
+
+        dmpl = self._evaluate(self.dmpl)
+        bp = self._evaluate(self.bp)
+        self.assertAlmostEqual(
+            self._column(dmpl, "saldo_final", 5),
+            bp["patrimonio_liquido"],
+            places=2,
+        )
+
+    def test_the_result_reaches_the_retained_earnings_column(self):
+        """The result of the year lands on retained earnings, from the DRE.
+
+        It is not on the account: the closing entry of the year is not booked,
+        so the result lives on the result accounts. The statement reads it from
+        the income statement, the same way the balance sheet does.
+        """
+        self._post([(self.caixa, 5000.0, 0.0), (self.receita, 0.0, 5000.0)])
+        r = self._evaluate(self.dmpl)
+        self.assertAlmostEqual(self._column(r, "resultado", 3), 5000.0, places=2)
+        self.assertAlmostEqual(self._column(r, "saldo_final", 3), 5000.0, places=2)
+
+
+@tagged("post_install", "-at_install")
+class TestDlpa(EquityCommon):
+    """The DLPA is the retained earnings column of the DMPL, shown as a list.
+
+    It inherits the scenario of the DMPL on purpose: the two statements read
+    the same movements, and reading them apart is what would let them drift.
+    """
+
+    def test_it_ties_and_agrees_with_the_dmpl(self):
+        self._post([(self.caixa, 20000.0, 0.0), (self.capital, 0.0, 20000.0)])
+        self._post([(self.caixa, 7000.0, 0.0), (self.receita, 0.0, 7000.0)])
+        self._post([(self.lucros, 1200.0, 0.0), (self.dividendos, 0.0, 1200.0)])
+        self._post([(self.lucros, 800.0, 0.0), (self.reserva, 0.0, 800.0)])
+
+        dlpa = self._evaluate(self.env.ref("l10n_br_mis_report_sa.dlpa"))
+        # it ties: what is at the disposal, less what was appropriated
+        self.assertAlmostEqual(
+            dlpa["disposicao"] + dlpa["reservas"] + dlpa["dividendos"],
+            dlpa["saldo_final"],
+            places=2,
+        )
+        # 7000 of result, less 800 to the reserve and 1200 to the shareholders
+        self.assertAlmostEqual(dlpa["resultado"], 7000.0, places=2)
+        self.assertAlmostEqual(dlpa["reservas"], -800.0, places=2)
+        self.assertAlmostEqual(dlpa["dividendos"], -1200.0, places=2)
+        self.assertAlmostEqual(dlpa["saldo_final"], 5000.0, places=2)
+
+        # and it says the same as the retained earnings column of the DMPL
+        dmpl = self._evaluate(self.dmpl)
+        self.assertAlmostEqual(
+            dlpa["saldo_final"], self._column(dmpl, "saldo_final", 3), places=2
+        )


### PR DESCRIPTION
Fase 3 do PRD das demonstrações contábeis completas, empilhada na Fase 2
(kmee#741, a DFC).

## DMPL

É a única demonstração deste guarda-chuva que não é lista de linhas: é uma
**matriz**, com os componentes do patrimônio líquido nas colunas e os eventos
do período nas linhas. O mis_builder produz isso com `mis.report.subkpi`, e foi
o recurso que decidiu que a DMPL cabia aqui em vez de exigir relatório próprio
em QWeb.

Consequência: as colunas já estão ocupadas, então a comparação com o exercício
anterior é gerar a demonstração de novo com outra data base.

Dois pontos de desenho:

- **aumento e redução de capital** saem dos CRÉDITOS e dos DÉBITOS do período,
  o que separa os dois eventos sem exigir uma conta para cada um;
- **o resultado do exercício vem da DRE**, por subrelatório, porque o Odoo não
  escritura o encerramento e o resultado vive nas contas de resultado. O saldo
  final da coluna de lucros acumulados soma o resultado ao saldo contábil,
  exatamente como o Balanço faz. É isso que permite à coluna Total reproduzir o
  patrimônio líquido do Balanço, e um teste exige essa igualdade.

## DLPA

Vem junto porque uma contém a outra: o art. 186, § 2º dispensa da DLPA quem
publica a DMPL, e a DLPA é a coluna de lucros acumulados apresentada em lista.

Uma inferência declarada: a separação entre transferência para reservas e
dividendo vem do movimento das reservas, não da contrapartida do lançamento. As
duas linhas somadas reproduzem a variação da conta de lucros acumulados, então o
total fecha mesmo quando a divisão entre elas erra.

## Testes

Cinco novos, e o que eles exigem é que a matriz FECHE: cada coluna do saldo
inicial ao final, e a coluna Total concordando com o Balanço.

Rodando tudo junto (l10n_br_coa, l10n_br_mis_report e l10n_br_mis_report_sa):
23 testes, 0 falhas.

## Ponto para a revisão

A DMPL não tem linha de "ajustes de exercícios anteriores" nem de "dividendo
adicional proposto". Ambas existem no modelo do CPC 26, e nenhuma das duas é
identificável pelo saldo da conta: exigem marcar o lançamento. Vale decidir se
entram como linha manual ou se ficam para quando houver classificação por
lançamento.
