### PR TITLE
[16.0][ADD] l10n_br_mis_report_sa: DRA e DVA

### DIFF
--- a/l10n_br_mis_report_sa/README.rst
+++ b/l10n_br_mis_report_sa/README.rst
@@ -47,6 +47,11 @@ Acumulados** (art. 186 da Lei 6.404/76). Publicar a DMPL dispensa a
 DLPA, por força do art. 186, § 2º, e por isso as duas vêm juntas: quem
 publica a segunda não precisa da primeira.
 
+Com a DRA e a DVA, o módulo completa o conjunto: **DFC, DMPL, DLPA, DRA
+e DVA**, que somadas ao Balanço e à DRE do ``l10n_br_mis_report`` cobrem
+as demonstrações do art. 176 da Lei 6.404/76 e as que o CPC 26
+acrescenta.
+
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
    Only for development or testing purpose, do not use in production.

--- a/l10n_br_mis_report_sa/__manifest__.py
+++ b/l10n_br_mis_report_sa/__manifest__.py
@@ -19,6 +19,8 @@
         "data/mis_report_dfc.xml",
         "data/mis_report_dmpl.xml",
         "data/mis_report_dlpa.xml",
+        "data/mis_report_dra.xml",
+        "data/mis_report_dva.xml",
         "data/mis_report_instance.xml",
     ],
 }

--- a/l10n_br_mis_report_sa/data/mis_report_dra.xml
+++ b/l10n_br_mis_report_sa/data/mis_report_dra.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 KMEE
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!--
+      Demonstração do Resultado Abrangente (CPC 26 R1, itens 81 a 105).
+
+      Ela começa onde a DRE termina: a primeira linha é o resultado líquido, lido
+      da DRE por subrelatório, e a ele se somam os resultados que a norma manda
+      reconhecer no patrimônio líquido em vez de no resultado do período. O
+      CPC 26 permite apresentar as duas em demonstração única; aqui elas são
+      separadas, que é a forma mais usada no Brasil.
+
+      Empresa que não tem operação no exterior, hedge designado, plano de
+      benefício a empregados nem instrumento mensurado a valor justo por
+      resultado abrangente vai ver todas as linhas de outros resultados
+      abrangentes em zero, e o resultado abrangente igual ao resultado líquido.
+      Isso é o correto, não uma falha de configuração.
+    -->
+    <record id="dra" model="mis.report">
+        <field name="name">DRA - Demonstração do Resultado Abrangente</field>
+        <field name="description">Demonstração do Resultado Abrangente</field>
+        <field name="move_lines_source" ref="account.model_account_move_line" />
+    </record>
+
+    <record id="dra_subreport_dre" model="mis.report.subreport">
+        <field name="name">dre</field>
+        <field name="report_id" ref="dra" />
+        <field name="subreport_id" ref="l10n_br_mis_report.dre" />
+    </record>
+
+    <record id="dra_resultado" model="mis.report.kpi">
+        <field name="sequence">10</field>
+        <field name="report_id" ref="dra" />
+        <field name="description">Resultado líquido do exercício</field>
+        <field name="name">resultado</field>
+        <field name="expression">dre.resultado_liquido</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dra_header_oci" model="mis.report.kpi">
+        <field name="sequence">20</field>
+        <field name="report_id" ref="dra" />
+        <field name="description">Outros resultados abrangentes</field>
+        <field name="name">header_oci</field>
+        <field name="type">str</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dra_cambial" model="mis.report.kpi">
+        <field name="sequence">30</field>
+        <field name="report_id" ref="dra" />
+        <field name="description">Variação cambial de investimento no exterior</field>
+        <field name="name">cambial</field>
+        <field name="expression">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_oci_translation').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dra_hedge" model="mis.report.kpi">
+        <field name="sequence">40</field>
+        <field name="report_id" ref="dra" />
+        <field name="description">Hedge de fluxo de caixa</field>
+        <field name="name">hedge</field>
+        <field name="expression">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_oci_hedge').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dra_atuarial" model="mis.report.kpi">
+        <field name="sequence">50</field>
+        <field name="report_id" ref="dra" />
+        <field name="description">Ganhos e perdas atuariais</field>
+        <field name="name">atuarial</field>
+        <field name="expression">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_oci_actuarial').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dra_valor_justo" model="mis.report.kpi">
+        <field name="sequence">60</field>
+        <field name="report_id" ref="dra" />
+        <field name="description">Ajuste de instrumentos financeiros a valor justo</field>
+        <field name="name">valor_justo</field>
+        <field name="expression">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_oci_fair_value').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dra_total_oci" model="mis.report.kpi">
+        <field name="sequence">70</field>
+        <field name="report_id" ref="dra" />
+        <field name="description">= Total dos outros resultados abrangentes</field>
+        <field name="name">total_oci</field>
+        <field name="expression">cambial+hedge+atuarial+valor_justo</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dra_abrangente" model="mis.report.kpi">
+        <field name="sequence">80</field>
+        <field name="report_id" ref="dra" />
+        <field name="description">= RESULTADO ABRANGENTE TOTAL</field>
+        <field name="name">abrangente</field>
+        <field name="expression">resultado+total_oci</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+</odoo>

--- a/l10n_br_mis_report_sa/data/mis_report_dva.xml
+++ b/l10n_br_mis_report_sa/data/mis_report_dva.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 KMEE
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <!--
+      Demonstração do Valor Adicionado (CPC 09). O art. 176, inciso V da Lei
+      6.404/76 a exige da companhia aberta.
+
+      Ela reclassifica a DRE por uma pergunta diferente: em vez de quanto sobrou
+      para o acionista, quanta riqueza a empresa gerou e para quem ela foi. Por
+      isso a mesma despesa aparece aqui noutra linha: salário é pessoal,
+      aluguel é remuneração de capital de terceiros, IPTU é imposto, e energia
+      é insumo. É a terceira dimensão de classificação das contas.
+
+      A IDENTIDADE QUE ELA TEM QUE SATISFAZER: o total distribuído (8) é igual
+      ao valor adicionado a distribuir (7). Isso não é coincidência nem sorte de
+      arredondamento: é a própria DRE rearranjada, e só fecha se a classificação
+      cobrir todas as contas de resultado uma vez cada. Uma conta sem
+      classificação, ou com duas, quebra a igualdade, e é isso que o teste
+      verifica.
+
+      A remuneração de capitais próprios (8.4) é o resultado do exercício, lido
+      da DRE por subrelatório: é o que sobra para o acionista, retido ou
+      distribuído.
+
+      A DEPRECIAÇÃO tem linha própria (item 4) e por isso não entra nos insumos:
+      contá-la nos dois lugares tiraria duas vezes a mesma riqueza.
+
+      LIMITAÇÃO. As devoluções de venda estão classificadas junto com os
+      tributos sobre o faturamento, porque as duas reduzem a receita bruta pelo
+      mesmo grupo de contas do plano. O CPC 09 quer a devolução reduzindo a
+      receita e o tributo na distribuição. Separá-las exige contas próprias, e o
+      total a distribuir não muda por causa disso.
+    -->
+    <record id="dva" model="mis.report">
+        <field name="name">DVA - Demonstração do Valor Adicionado</field>
+        <field name="description">Demonstração do Valor Adicionado</field>
+        <field name="move_lines_source" ref="account.model_account_move_line" />
+    </record>
+
+    <record id="dva_subreport_dre" model="mis.report.subreport">
+        <field name="name">dre</field>
+        <field name="report_id" ref="dva" />
+        <field name="subreport_id" ref="l10n_br_mis_report.dre" />
+    </record>
+
+    <record id="dva_header_receitas" model="mis.report.kpi">
+        <field name="sequence">10</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">1 - RECEITAS</field>
+        <field name="name">header_receitas</field>
+        <field name="type">str</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dva_vendas" model="mis.report.kpi">
+        <field name="sequence">20</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">1.1) Vendas de mercadorias, produtos e serviços</field>
+        <field name="name">vendas</field>
+        <field name="expression">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_revenue').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_outras_receitas" model="mis.report.kpi">
+        <field name="sequence">30</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">1.2) Outras receitas</field>
+        <field name="name">outras_receitas</field>
+        <field name="expression">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_other_operating_results').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_receitas" model="mis.report.kpi">
+        <field name="sequence">40</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">= Total das receitas</field>
+        <field name="name">receitas</field>
+        <field name="expression">vendas+outras_receitas</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dva_header_insumos" model="mis.report.kpi">
+        <field name="sequence">50</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">2 - INSUMOS ADQUIRIDOS DE TERCEIROS</field>
+        <field name="name">header_insumos</field>
+        <field name="type">str</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dva_insumos" model="mis.report.kpi">
+        <field name="sequence">60</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">2.1) Custos, materiais, energia e serviços de terceiros</field>
+        <field name="name">insumos</field>
+        <field name="expression">+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_dva_inputs').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_valor_bruto" model="mis.report.kpi">
+        <field name="sequence">70</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">3 - VALOR ADICIONADO BRUTO</field>
+        <field name="name">valor_bruto</field>
+        <field name="expression">receitas-insumos</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dva_depreciacao" model="mis.report.kpi">
+        <field name="sequence">80</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">4 - DEPRECIAÇÃO, AMORTIZAÇÃO E EXAUSTÃO</field>
+        <field name="name">depreciacao</field>
+        <field name="expression">+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_depreciation_expense').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_valor_liquido" model="mis.report.kpi">
+        <field name="sequence">90</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">5 - VALOR ADICIONADO LÍQUIDO PRODUZIDO</field>
+        <field name="name">valor_liquido</field>
+        <field name="expression">valor_bruto-depreciacao</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dva_transferencia" model="mis.report.kpi">
+        <field name="sequence">100</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">6 - VALOR ADICIONADO RECEBIDO EM TRANSFERÊNCIA</field>
+        <field name="name">transferencia</field>
+        <field name="expression">-bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_dva_transfer').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_valor_distribuir" model="mis.report.kpi">
+        <field name="sequence">110</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">7 - VALOR ADICIONADO TOTAL A DISTRIBUIR</field>
+        <field name="name">valor_distribuir</field>
+        <field name="expression">valor_liquido+transferencia</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dva_header_distribuicao" model="mis.report.kpi">
+        <field name="sequence">120</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">8 - DISTRIBUIÇÃO DO VALOR ADICIONADO</field>
+        <field name="name">header_distribuicao</field>
+        <field name="type">str</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+    <record id="dva_pessoal" model="mis.report.kpi">
+        <field name="sequence">130</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">8.1) Pessoal</field>
+        <field name="name">pessoal</field>
+        <field name="expression">+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_dva_personnel').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_impostos" model="mis.report.kpi">
+        <field name="sequence">140</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">8.2) Impostos, taxas e contribuições</field>
+        <field name="name">impostos</field>
+        <field name="expression">+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_dva_taxes').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_impostos_federais" model="mis.report.kpi">
+        <field name="sequence">150</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">8.2.1) Federais</field>
+        <field name="name">impostos_federais</field>
+        <field name="expression">+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_dva_taxes_federal').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_impostos_estaduais" model="mis.report.kpi">
+        <field name="sequence">160</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">8.2.2) Estaduais</field>
+        <field name="name">impostos_estaduais</field>
+        <field name="expression">+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_dva_taxes_state').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_impostos_municipais" model="mis.report.kpi">
+        <field name="sequence">170</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">8.2.3) Municipais</field>
+        <field name="name">impostos_municipais</field>
+        <field name="expression">+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_dva_taxes_municipal').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_terceiros" model="mis.report.kpi">
+        <field name="sequence">180</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">8.3) Remuneração de capitais de terceiros</field>
+        <field name="name">terceiros</field>
+        <field name="expression">+bal[('tag_ids', '=', ref('l10n_br_coa.account_tag_dva_third_party_capital').id)]</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_proprios" model="mis.report.kpi">
+        <field name="sequence">190</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">8.4) Remuneração de capitais próprios</field>
+        <field name="name">proprios</field>
+        <field name="expression">dre.resultado_liquido</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+    </record>
+
+    <record id="dva_distribuido" model="mis.report.kpi">
+        <field name="sequence">200</field>
+        <field name="report_id" ref="dva" />
+        <field name="description">= Total distribuído</field>
+        <field name="name">distribuido</field>
+        <field name="expression">pessoal+impostos+terceiros+proprios</field>
+        <field name="type">num</field>
+        <field name="compare_method">pct</field>
+        <field name="style_id"
+            ref="l10n_br_mis_report.mis_report_style_l10n_br_negrito" />
+    </record>
+
+</odoo>

--- a/l10n_br_mis_report_sa/data/mis_report_instance.xml
+++ b/l10n_br_mis_report_sa/data/mis_report_instance.xml
@@ -96,4 +96,68 @@
         <field name="offset">0</field>
         <field name="duration">1</field>
     </record>
+
+    <record id="instance_dra" model="mis.report.instance">
+        <field name="name">DRA - exercício atual e anterior</field>
+        <field name="report_id" ref="dra" />
+        <field name="sequence">80</field>
+        <field name="company_id" eval="False" />
+        <field name="target_move">posted</field>
+        <field name="comparison_mode" eval="True" />
+        <field name="display_columns_description" eval="True" />
+    </record>
+
+    <record id="instance_dra_ant" model="mis.report.instance.period">
+        <field name="name">Exercício anterior</field>
+        <field name="report_instance_id" ref="instance_dra" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">10</field>
+        <field name="type">y</field>
+        <field name="offset">-1</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dra_atual" model="mis.report.instance.period">
+        <field name="name">Exercício atual</field>
+        <field name="report_instance_id" ref="instance_dra" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">20</field>
+        <field name="type">y</field>
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dva" model="mis.report.instance">
+        <field name="name">DVA - exercício atual e anterior</field>
+        <field name="report_id" ref="dva" />
+        <field name="sequence">90</field>
+        <field name="company_id" eval="False" />
+        <field name="target_move">posted</field>
+        <field name="comparison_mode" eval="True" />
+        <field name="display_columns_description" eval="True" />
+    </record>
+
+    <record id="instance_dva_ant" model="mis.report.instance.period">
+        <field name="name">Exercício anterior</field>
+        <field name="report_instance_id" ref="instance_dva" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">10</field>
+        <field name="type">y</field>
+        <field name="offset">-1</field>
+        <field name="duration">1</field>
+    </record>
+
+    <record id="instance_dva_atual" model="mis.report.instance.period">
+        <field name="name">Exercício atual</field>
+        <field name="report_instance_id" ref="instance_dva" />
+        <field name="source">actuals</field>
+        <field name="mode">relative</field>
+        <field name="sequence">20</field>
+        <field name="type">y</field>
+        <field name="offset">0</field>
+        <field name="duration">1</field>
+    </record>
 </odoo>

--- a/l10n_br_mis_report_sa/readme/DESCRIPTION.md
+++ b/l10n_br_mis_report_sa/readme/DESCRIPTION.md
@@ -14,3 +14,7 @@ Nesta versão, além da DFC: a **Demonstração das Mutações do Patrimônio L�
 (CPC 26 R1) e a **Demonstração dos Lucros ou Prejuízos Acumulados** (art. 186 da
 Lei 6.404/76). Publicar a DMPL dispensa a DLPA, por força do art. 186, § 2º, e
 por isso as duas vêm juntas: quem publica a segunda não precisa da primeira.
+
+Com a DRA e a DVA, o módulo completa o conjunto: **DFC, DMPL, DLPA, DRA e DVA**,
+que somadas ao Balanço e à DRE do `l10n_br_mis_report` cobrem as demonstrações
+do art. 176 da Lei 6.404/76 e as que o CPC 26 acrescenta.

--- a/l10n_br_mis_report_sa/static/description/index.html
+++ b/l10n_br_mis_report_sa/static/description/index.html
@@ -384,6 +384,10 @@ Líquido</strong> (CPC 26 R1) e a <strong>Demonstração dos Lucros ou Prejuízo
 Acumulados</strong> (art. 186 da Lei 6.404/76). Publicar a DMPL dispensa a
 DLPA, por força do art. 186, § 2º, e por isso as duas vêm juntas: quem
 publica a segunda não precisa da primeira.</p>
+<p>Com a DRA e a DVA, o módulo completa o conjunto: <strong>DFC, DMPL, DLPA, DRA
+e DVA</strong>, que somadas ao Balanço e à DRE do <tt class="docutils literal">l10n_br_mis_report</tt> cobrem
+as demonstrações do art. 176 da Lei 6.404/76 e as que o CPC 26
+acrescenta.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.

--- a/l10n_br_mis_report_sa/tests/__init__.py
+++ b/l10n_br_mis_report_sa/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_dfc
 from . import test_dmpl
+from . import test_dra_dva

--- a/l10n_br_mis_report_sa/tests/test_dra_dva.py
+++ b/l10n_br_mis_report_sa/tests/test_dra_dva.py
@@ -1,0 +1,192 @@
+# Copyright 2026 KMEE
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+"""The comprehensive income and the value added statements.
+
+Each one has an identity that defines it, and the tests demand the identity
+rather than the presence of the lines. On the value added statement, what is
+distributed has to equal what there is to distribute, and that only holds if
+the classification covers every result account exactly once.
+"""
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestDraDva(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.company = cls.company_data["company"]
+        cls.journal = cls.company_data["default_journal_misc"]
+        cls.dra = cls.env.ref("l10n_br_mis_report_sa.dra")
+        cls.dva = cls.env.ref("l10n_br_mis_report_sa.dva")
+
+        def account(code, name, account_type, *tags):
+            return cls.env["account.account"].create(
+                {
+                    "code": code,
+                    "name": name,
+                    "account_type": account_type,
+                    "company_id": cls.company.id,
+                    "tag_ids": [
+                        (4, cls.env.ref("l10n_br_coa.%s" % tag).id) for tag in tags
+                    ],
+                }
+            )
+
+        cls.caixa = account(
+            "DVA10", "Caixa", "asset_cash",
+            "account_tag_current_assets_cash", "account_tag_cash_and_equivalents",
+        )
+        cls.deprec_acum = account(
+            "DVA14", "Depreciação Acumulada", "asset_fixed",
+            "account_tag_fixed_assets_depreciation",
+            "account_tag_cash_flow_result_adjustment",
+        )
+        cls.ajuste_pl = account(
+            "DVA24", "Ajustes de Avaliação Patrimonial", "equity",
+            "account_tag_equity_valuation_adjustment",
+            "account_tag_cash_flow_non_cash",
+        )
+        cls.receita = account(
+            "DVA90", "Vendas", "income",
+            "account_tag_revenue", "account_tag_result",
+        )
+        cls.insumo = account(
+            "DVA91", "Energia Elétrica", "expense",
+            "account_tag_admin_expenses", "account_tag_result",
+            "account_tag_dva_inputs",
+        )
+        cls.salario = account(
+            "DVA92", "Salários", "expense",
+            "account_tag_other_general_expenses", "account_tag_result",
+            "account_tag_dva_personnel",
+        )
+        cls.imposto = account(
+            "DVA93", "IPTU", "expense",
+            "account_tag_other_general_expenses", "account_tag_result",
+            "account_tag_dva_taxes", "account_tag_dva_taxes_municipal",
+        )
+        cls.juros = account(
+            "DVA94", "Juros Passivos", "expense",
+            "account_tag_expenses_financial", "account_tag_result",
+            "account_tag_dva_third_party_capital",
+        )
+        cls.despesa_deprec = account(
+            "DVA95", "Depreciação", "expense",
+            "account_tag_other_general_expenses", "account_tag_result",
+            "account_tag_depreciation_expense",
+        )
+        cls.receita_financeira = account(
+            "DVA96", "Rendimentos de Aplicações", "income_other",
+            "account_tag_revenue_financial", "account_tag_result",
+            "account_tag_dva_transfer",
+        )
+        cls.oci_hedge = account(
+            "DVA97", "Hedge de Fluxo de Caixa", "income_other",
+            "account_tag_oci_hedge", "account_tag_result",
+            "account_tag_dva_inputs",
+        )
+
+        cls.date_from = "2026-01-01"
+        cls.date_to = "2026-12-31"
+
+    @classmethod
+    def _post(cls, lines, date="2026-06-15"):
+        move = cls.env["account.move"].create(
+            {
+                "journal_id": cls.journal.id,
+                "company_id": cls.company.id,
+                "date": date,
+                "line_ids": [
+                    (0, 0, {"account_id": acc.id, "debit": d, "credit": c})
+                    for acc, d, c in lines
+                ],
+            }
+        )
+        move.action_post()
+        return move
+
+    def _evaluate(self, report):
+        aep = report._prepare_aep(self.company)
+        return report.with_company(self.company).evaluate(
+            aep, date_from=self.date_from, date_to=self.date_to
+        )
+
+    def _movimento_completo(self):
+        """Um exercício que toca cada linha da distribuição."""
+        self._post([(self.caixa, 10000.0, 0.0), (self.receita, 0.0, 10000.0)])
+        self._post([(self.insumo, 1500.0, 0.0), (self.caixa, 0.0, 1500.0)])
+        self._post([(self.salario, 2500.0, 0.0), (self.caixa, 0.0, 2500.0)])
+        self._post([(self.imposto, 700.0, 0.0), (self.caixa, 0.0, 700.0)])
+        self._post([(self.juros, 400.0, 0.0), (self.caixa, 0.0, 400.0)])
+        self._post([(self.despesa_deprec, 600.0, 0.0), (self.deprec_acum, 0.0, 600.0)])
+        self._post([(self.caixa, 300.0, 0.0), (self.receita_financeira, 0.0, 300.0)])
+
+    def test_the_value_added_distributed_equals_the_value_added_to_distribute(self):
+        """The identity that defines the statement.
+
+        It is the income statement rearranged, so it only holds when the
+        classification covers every result account exactly once. An account with
+        no destination, or with two, breaks the equality.
+        """
+        self._movimento_completo()
+        r = self._evaluate(self.dva)
+        self.assertAlmostEqual(
+            r["valor_distribuir"], r["distribuido"], places=2,
+            msg="há %.2f de valor adicionado a distribuir e %.2f distribuído"
+            % (r["valor_distribuir"], r["distribuido"]),
+        )
+
+    def test_each_line_of_the_value_added_carries_its_own_nature(self):
+        """The same expense lands where the CPC 09 puts it, not where the DRE does."""
+        self._movimento_completo()
+        r = self._evaluate(self.dva)
+        self.assertAlmostEqual(r["vendas"], 10000.0, places=2)
+        self.assertAlmostEqual(r["insumos"], 1500.0, places=2)
+        self.assertAlmostEqual(r["depreciacao"], 600.0, places=2)
+        self.assertAlmostEqual(r["transferencia"], 300.0, places=2)
+        self.assertAlmostEqual(r["pessoal"], 2500.0, places=2)
+        self.assertAlmostEqual(r["impostos"], 700.0, places=2)
+        self.assertAlmostEqual(r["terceiros"], 400.0, places=2)
+        # 10000 - 1500 - 600 + 300 = 8200 of wealth generated
+        self.assertAlmostEqual(r["valor_distribuir"], 8200.0, places=2)
+        # what is left after paying everyone is the shareholder's
+        self.assertAlmostEqual(r["proprios"], 4600.0, places=2)
+
+    def test_depreciation_is_not_counted_as_an_input(self):
+        """It has a line of its own, so counting it twice would remove the same
+        wealth from the statement twice."""
+        self._post([(self.caixa, 5000.0, 0.0), (self.receita, 0.0, 5000.0)])
+        self._post([(self.despesa_deprec, 800.0, 0.0), (self.deprec_acum, 0.0, 800.0)])
+        r = self._evaluate(self.dva)
+        self.assertAlmostEqual(r["insumos"], 0.0, places=2)
+        self.assertAlmostEqual(r["depreciacao"], 800.0, places=2)
+        self.assertAlmostEqual(r["valor_distribuir"], 4200.0, places=2)
+        self.assertAlmostEqual(r["valor_distribuir"], r["distribuido"], places=2)
+
+    def test_taxes_are_broken_down_by_sphere(self):
+        """The CPC 09 model wants the tax distribution split by government level."""
+        self._movimento_completo()
+        r = self._evaluate(self.dva)
+        self.assertAlmostEqual(r["impostos_municipais"], 700.0, places=2)
+        self.assertAlmostEqual(r["impostos_estaduais"], 0.0, places=2)
+        self.assertAlmostEqual(r["impostos_federais"], 0.0, places=2)
+
+    def test_comprehensive_income_starts_where_the_income_statement_ends(self):
+        """The net result is the first line, and other comprehensive income adds to it."""
+        self._post([(self.caixa, 4000.0, 0.0), (self.receita, 0.0, 4000.0)])
+        self._post([(self.salario, 1000.0, 0.0), (self.caixa, 0.0, 1000.0)])
+        r = self._evaluate(self.dra)
+        self.assertAlmostEqual(r["resultado"], 3000.0, places=2)
+        self.assertAlmostEqual(r["total_oci"], 0.0, places=2)
+        self.assertAlmostEqual(r["abrangente"], 3000.0, places=2)
+
+    def test_other_comprehensive_income_adds_to_the_result(self):
+        """A hedge gain is recognised in equity, not in the result of the year."""
+        self._post([(self.caixa, 4000.0, 0.0), (self.receita, 0.0, 4000.0)])
+        self._post([(self.ajuste_pl, 900.0, 0.0), (self.oci_hedge, 0.0, 900.0)])
+        r = self._evaluate(self.dra)
+        self.assertAlmostEqual(r["hedge"], 900.0, places=2)
+        self.assertAlmostEqual(r["abrangente"], r["resultado"] + 900.0, places=2)


### PR DESCRIPTION
Fase 4, que fecha o conjunto. Empilha no PR das contas (kmee#743), que ela
precisa para distribuir o valor adicionado corretamente.

## DRA

Começa onde a DRE termina: a primeira linha é o resultado líquido, por
subrelatório, e a ele se somam os resultados que o CPC 26 manda reconhecer no
patrimônio líquido em vez de no resultado do período (variação cambial de
investimento no exterior, hedge de fluxo de caixa, ganhos e perdas atuariais,
ajuste a valor justo).

Empresa que não tem nenhuma dessas situações vê todas as linhas em zero e o
resultado abrangente igual ao líquido. Isso é o correto, não configuração
faltando, e está dito no comentário do relatório para ninguém sair procurando
defeito.

## DVA

Ela reclassifica a DRE por outra pergunta: em vez de quanto sobrou para o
acionista, quanta riqueza a empresa gerou e para quem foi. Por isso a mesma
despesa aparece noutra linha, e por isso a classificação da conta precisou de
uma terceira dimensão.

**A identidade que a define**: o total distribuído (8) é igual ao valor
adicionado a distribuir (7). Isso não é coincidência nem sorte de
arredondamento: é a DRE rearranjada. Só fecha se a classificação cobrir cada
conta de resultado exatamente uma vez, e é justamente isso que o teste exige.
Uma conta sem destino, ou com dois, quebra a igualdade.

A remuneração de capitais próprios é o resultado do exercício, lido da DRE: é o
que sobra para o acionista, retido ou distribuído.

## Testes

Seis novos. Os três módulos juntos: 29 testes, 0 falhas.

## Limitação declarada

As devoluções de venda estão classificadas junto com os tributos sobre o
faturamento, porque compartilham o mesmo grupo de contas nos planos. O CPC 09
quer a devolução reduzindo a receita e o tributo na distribuição. Separá-las
exige contas próprias; o total a distribuir não muda por isso.
